### PR TITLE
Feature: Message Payloads

### DIFF
--- a/packages/server/src/api/audiences/audiences.service.ts
+++ b/packages/server/src/api/audiences/audiences.service.ts
@@ -338,7 +338,6 @@ export class AudiencesService {
     if (from) {
       try {
         fromAud = await this.findOne(account, from);
-        //this.logger.debug('Audience: ' + fromAud);
       } catch (err) {
         this.logger.error('Error: ' + err);
         return Promise.reject(err);
@@ -347,7 +346,6 @@ export class AudiencesService {
     if (to) {
       try {
         toAud = await this.findOne(account, to);
-        //this.logger.debug('Audience: ' + toAud);
       } catch (err) {
         this.logger.error('Error: ' + err);
         return Promise.reject(err);

--- a/packages/server/src/api/events/dto/event.dto.ts
+++ b/packages/server/src/api/events/dto/event.dto.ts
@@ -22,4 +22,8 @@ export class EventDto {
   @IsNotEmpty()
   @IsOptional()
   public source: string;
+
+  @IsString()
+  @IsOptional()
+  public payload: string;
 }

--- a/packages/server/src/api/events/events.controller.ts
+++ b/packages/server/src/api/events/events.controller.ts
@@ -139,6 +139,7 @@ export class EventsController {
             correlationValue: currentEvent.userId,
             event: currentEvent.event,
             source: 'posthog',
+            payload: undefined,
           };
 
           //currentEvent

--- a/packages/server/src/api/templates/templates.service.ts
+++ b/packages/server/src/api/templates/templates.service.ts
@@ -94,7 +94,7 @@ export class TemplatesService {
           to: customer.phEmail ? customer.phEmail : customer.email,
           tags,
           subject: template.subject,
-          text: template.text,
+          text: event?.payload ? event.payload : template.text,
         });
         break;
       case 'slack':
@@ -108,7 +108,7 @@ export class TemplatesService {
           token: installation.installation.bot.token,
           args: {
             channel: customer.slackId,
-            text: template.slackMessage,
+            text: event?.payload ? event.payload : template.slackMessage,
             tags,
           },
         });


### PR DESCRIPTION
Adding ```payload:string``` to an event will now replace the template for an audience with the text of the payload.