### PR TITLE
Prevent drawer width juming + submenu indent

### DIFF
--- a/packages/client/src/components/Drawer/Drawer.tsx
+++ b/packages/client/src/components/Drawer/Drawer.tsx
@@ -120,7 +120,7 @@ export default function ResponsiveDrawer() {
                           <path d="M6 6L14 10L6 14V6Z" fill="currentColor" />
                         </svg>
                       </Disclosure.Button>
-                      <Disclosure.Panel className="space-y-1">
+                      <Disclosure.Panel className="space-y-1 ml-3">
                         {item.children?.map((subItem) => (
                           <>
                             {userState.userPermissions?.includes(
@@ -237,7 +237,7 @@ export default function ResponsiveDrawer() {
           </Transition.Root>
 
           <div
-            className={`flex-grow flex-col bg-cyan-700 pt-5 pb-4 h-full transition-all duration-500 ease-in-out max-w-[225px] hidden lg:flex`}
+            className={`flex-grow flex-col bg-cyan-700 pt-5 pb-4 h-full transition-all duration-500 ease-in-out min-w-[225px] max-w-[300px] hidden lg:flex`}
           >
             <div className="flex flex-shrink-0 items-center px-4">
               <img className="h-8" src={LaudspeakerIcon} alt="Laudspeaker" />


### PR DESCRIPTION
## Context
At the moment when using the menu in the drawer on the side, the menu width jumps + there is no clear difference between what is a "main item" and what is a "sub menu item" when collapsed.

## What has been done?
- Added a minimum width of 225px for the drawer (previous max width)
- Added a margin-left for the "submenu items"

## How does the change look like?
Before:
![image](https://i.gyazo.com/a5fdfefeb3733ba53a82294773b9740b.gif)

After:
![image](https://i.gyazo.com/09ba39e28398252fe8f35a10d84299f3.gif)