### PR TITLE
cp instead of mv to not introduce changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Add a `.env` file to both `packages/server` and `packages/client`.
 
 We have provided examples which you can use:
 
-`mv env-server-example packages/server/.env` and `mv env-client-example packages/client/.env`
+`cp env-server-example packages/server/.env` and `cp env-client-example packages/client/.env`
 
 Make sure you fill in the fields in the env files before running.
 


### PR DESCRIPTION
I was following the readme to setup my env and then noticed I had local changes because the defaults were moved instead of copied. 