### PR TITLE
Add upsert method on customers

### DIFF
--- a/packages/server/src/api/customers/customers.service.ts
+++ b/packages/server/src/api/customers/customers.service.ts
@@ -727,7 +727,7 @@ export class CustomersService {
     account: Account,
     correlationKey: string,
     correlationValue: string | [],
-    transactionSession: ClientSession
+    transactionSession?: ClientSession
   ): Promise<CustomerDocument> {
     let customer: CustomerDocument; // Found customer
     const queryParam = {
@@ -735,9 +735,13 @@ export class CustomersService {
       [correlationKey]: correlationValue,
     };
     try {
-      customer = await this.CustomerModel.findOne(queryParam)
-        .session(transactionSession)
-        .exec();
+      if (transactionSession) {
+        customer = await this.CustomerModel.findOne(queryParam)
+          .session(transactionSession)
+          .exec();
+      } else {
+        customer = await this.CustomerModel.findOne(queryParam).exec();
+      }
       this.logger.debug('Found customer in correlationKVPair:' + customer.id);
     } catch (err) {
       return Promise.reject(err);


### PR DESCRIPTION
This is helpful to implement the Identify functionality provided by most event/analytics systems. At the beginning of each user session, the client should make a call to Identify the user, in this case a customer, and the client only has the info available to it, which is generally some sort of user identifier. Having an upsert method separate from the event tracking itself, allows the client to set or update attributes for that user (customer).

I've added the method here such that an api request can be made to this endpoint. I was going to add some tests for it, but doesn't seem like the project has been really setup for tests.