### PR TITLE
Adding ability to CC emails.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8016,18 +8016,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/clone-deep": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^2.0.4",
-        "kind-of": "^6.0.2",
-        "shallow-clone": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/clsx": {
       "version": "1.2.1",
       "license": "MIT",
@@ -12764,16 +12752,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "license": "MIT"
@@ -14947,13 +14925,13 @@
       }
     },
     "node_modules/mailgun.js": {
-      "version": "7.0.4",
-      "license": "MIT",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/mailgun.js/-/mailgun.js-8.2.1.tgz",
+      "integrity": "sha512-iKHCMehdUcWzBAp8KU2idLP7AbsTxQ8DjJev4Gvm430Dujul+ZkzKPgn40uYpb9BXGL5l8/w5jpf2pvw51df/w==",
       "dependencies": {
-        "axios": "^1.3.4",
+        "axios": "^1.3.3",
         "base-64": "^1.0.0",
-        "url-join": "^4.0.1",
-        "webpack-merge": "^5.4.0"
+        "url-join": "^4.0.1"
       }
     },
     "node_modules/make-dir": {
@@ -15667,15 +15645,6 @@
         "class-validator": {
           "optional": true
         }
-      }
-    },
-    "node_modules/nestjs-mailgun/node_modules/mailgun.js": {
-      "version": "8.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^1.3.4",
-        "base-64": "^1.0.0",
-        "url-join": "^4.0.1"
       }
     },
     "node_modules/nestjs-mailgun/node_modules/uuid": {
@@ -19986,16 +19955,6 @@
         "sha.js": "bin.js"
       }
     },
-    "node_modules/shallow-clone": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^6.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "license": "MIT",
@@ -22944,17 +22903,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/webpack-merge": {
-      "version": "5.8.0",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/webpack-node-externals": {
       "version": "3.0.0",
       "license": "MIT",
@@ -23052,10 +23000,6 @@
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
-    },
-    "node_modules/wildcard": {
-      "version": "2.0.0",
-      "license": "MIT"
     },
     "node_modules/windows-release": {
       "version": "4.0.0",
@@ -23678,7 +23622,7 @@
         "form-data": "^4.0.0",
         "liquidjs": "^9.42.0",
         "lodash": "^4.17.21",
-        "mailgun.js": "^7.0.4",
+        "mailgun.js": "^8.2.1",
         "mongoose": "^6.4.7",
         "multer": "^1.4.5-lts.1",
         "mysql2": "^2.3.3",
@@ -28790,14 +28734,6 @@
     "clone": {
       "version": "1.0.4"
     },
-    "clone-deep": {
-      "version": "4.0.1",
-      "requires": {
-        "is-plain-object": "^2.0.4",
-        "kind-of": "^6.0.2",
-        "shallow-clone": "^3.0.0"
-      }
-    },
     "clsx": {
       "version": "1.2.1"
     },
@@ -31791,12 +31727,6 @@
     "is-plain-obj": {
       "version": "3.0.0"
     },
-    "is-plain-object": {
-      "version": "2.0.4",
-      "requires": {
-        "isobject": "^3.0.1"
-      }
-    },
     "is-potential-custom-element-name": {
       "version": "1.0.1"
     },
@@ -33002,7 +32932,7 @@
         "jest": "^27.2.5",
         "liquidjs": "^9.42.0",
         "lodash": "^4.17.21",
-        "mailgun.js": "^7.0.4",
+        "mailgun.js": "^8.2.1",
         "mongoose": "^6.4.7",
         "multer": "^1.4.5-lts.1",
         "mysql2": "^2.3.3",
@@ -33511,12 +33441,13 @@
       }
     },
     "mailgun.js": {
-      "version": "7.0.4",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/mailgun.js/-/mailgun.js-8.2.1.tgz",
+      "integrity": "sha512-iKHCMehdUcWzBAp8KU2idLP7AbsTxQ8DjJev4Gvm430Dujul+ZkzKPgn40uYpb9BXGL5l8/w5jpf2pvw51df/w==",
       "requires": {
-        "axios": "^1.3.4",
+        "axios": "^1.3.3",
         "base-64": "^1.0.0",
-        "url-join": "^4.0.1",
-        "webpack-merge": "^5.4.0"
+        "url-join": "^4.0.1"
       }
     },
     "make-dir": {
@@ -33974,14 +33905,6 @@
             "iterare": "1.2.1",
             "tslib": "2.4.0",
             "uuid": "9.0.0"
-          }
-        },
-        "mailgun.js": {
-          "version": "8.0.1",
-          "requires": {
-            "axios": "^1.3.4",
-            "base-64": "^1.0.0",
-            "url-join": "^4.0.1"
           }
         },
         "uuid": {
@@ -36488,12 +36411,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "shallow-clone": {
-      "version": "3.0.1",
-      "requires": {
-        "kind-of": "^6.0.2"
-      }
-    },
     "shebang-command": {
       "version": "2.0.0",
       "requires": {
@@ -38344,13 +38261,6 @@
         }
       }
     },
-    "webpack-merge": {
-      "version": "5.8.0",
-      "requires": {
-        "clone-deep": "^4.0.1",
-        "wildcard": "^2.0.0"
-      }
-    },
     "webpack-node-externals": {
       "version": "3.0.0"
     },
@@ -38409,9 +38319,6 @@
       "requires": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
-    },
-    "wildcard": {
-      "version": "2.0.0"
     },
     "windows-release": {
       "version": "4.0.0",

--- a/packages/client/src/pages/EmailBuilder/EmailBuilder.tsx
+++ b/packages/client/src/pages/EmailBuilder/EmailBuilder.tsx
@@ -37,6 +37,7 @@ export interface Resource {
 const EmailBuilder = () => {
   const { name } = useParams();
   const [title, setTitle] = useState<string>("");
+  const [cc, setCC] = useState<string>("");
   const [templateName, setTemplateName] = useState<string>("My email template");
   const [editor, setEditor] = useState<grapesjs.Editor>();
   const [emailTemplateId, setEmailTemplateId] = useState<string>("");
@@ -111,6 +112,7 @@ const EmailBuilder = () => {
     const populateEmailBuilder = async () => {
       const { data } = await getTemplate(name);
       setTitle(data.subject);
+      setCC(data.cc.join());
       setTemplateName(name);
       setEmailTemplateId(data.id);
       setText(data.text);
@@ -125,6 +127,9 @@ const EmailBuilder = () => {
       const reqBody = {
         name: templateName,
         subject: title,
+        cc: cc.split(",").filter(function (entry) {
+          return /\S/.test(entry);
+        }),
         text: editor?.getHtml(),
         style: editor?.getCss(),
         type: "email",
@@ -226,6 +231,19 @@ const EmailBuilder = () => {
             setIsPreview={setIsPreview}
             possibleAttributes={possibleAttributes}
             inputRef={subjectRef}
+          />
+          <MergeTagInput
+            value={cc}
+            placeholder={"email@email.com,email_two@email.com"}
+            name="cc"
+            id="title"
+            fullWidth
+            setValue={setCC}
+            onChange={(e) => setCC(e.target.value)}
+            labelShrink
+            isPreview={false}
+            setIsPreview={() => {}}
+            possibleAttributes={possibleAttributes}
           />
           <div id="emailBuilder" className="gjs-dashed" />
         </div>

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -59,7 +59,7 @@
     "form-data": "^4.0.0",
     "liquidjs": "^9.42.0",
     "lodash": "^4.17.21",
-    "mailgun.js": "^7.0.4",
+    "mailgun.js": "^8.2.1",
     "mongoose": "^6.4.7",
     "multer": "^1.4.5-lts.1",
     "mysql2": "^2.3.3",

--- a/packages/server/src/api/email/email.processor.ts
+++ b/packages/server/src/api/email/email.processor.ts
@@ -82,6 +82,7 @@ export class MessageProcessor {
           const sendgridMessage = await sg.send({
             from: job.data.from,
             to: job.data.to,
+            cc: job.data.cc,
             subject: subjectWithInsertedTags,
             html: textWithInsertedTags,
             personalizations: [
@@ -92,6 +93,7 @@ export class MessageProcessor {
                   customerId: job.data.customerId,
                   templateId: job.data.templateId,
                 },
+                cc: job.data.cc,
               },
             ],
           });
@@ -116,6 +118,7 @@ export class MessageProcessor {
           const mailgunMessage = await mg.messages.create(job.data.domain, {
             from: `${job.data.from} <${job.data.email}@${job.data.domain}>`,
             to: job.data.to,
+            cc: job.data.cc,
             subject: subjectWithInsertedTags,
             html: textWithInsertedTags,
             'v:audienceId': job.data.audienceId,

--- a/packages/server/src/api/templates/dto/create-template.dto.ts
+++ b/packages/server/src/api/templates/dto/create-template.dto.ts
@@ -1,5 +1,11 @@
 import { Trim } from 'class-sanitizer';
-import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+import {
+  IsEmail,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
 
 export class CreateTemplateDto {
   @Trim()
@@ -16,6 +22,9 @@ export class CreateTemplateDto {
   @IsNotEmpty()
   @IsOptional()
   public text: string;
+
+  @IsEmail({}, { each: true })
+  public cc: string[];
 
   @IsString()
   @IsNotEmpty()

--- a/packages/server/src/api/templates/dto/update-template.dto.ts
+++ b/packages/server/src/api/templates/dto/update-template.dto.ts
@@ -1,5 +1,11 @@
 import { Trim } from 'class-sanitizer';
-import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+  IsEmail,
+} from 'class-validator';
 
 export class UpdateTemplateDto {
   @Trim()
@@ -12,6 +18,9 @@ export class UpdateTemplateDto {
   @IsOptional()
   @MaxLength(2000)
   public subject: string;
+
+  @IsEmail({}, { each: true })
+  public cc: string[];
 
   @IsString()
   @IsNotEmpty()

--- a/packages/server/src/api/templates/entities/template.entity.ts
+++ b/packages/server/src/api/templates/entities/template.entity.ts
@@ -28,6 +28,9 @@ export class Template {
   @Column({ nullable: true })
   subject: string;
 
+  @Column('text', { nullable: false, array: true, default: [] })
+  cc: string[];
+
   @Column({ nullable: true })
   slackMessage: string;
 

--- a/packages/server/src/api/templates/templates.service.ts
+++ b/packages/server/src/api/templates/templates.service.ts
@@ -44,6 +44,7 @@ export class TemplatesService {
       case 'email':
         template.subject = createTemplateDto.subject;
         template.text = createTemplateDto.text;
+        template.cc = createTemplateDto.cc;
         template.style = createTemplateDto.style;
         break;
       case 'slack':
@@ -137,6 +138,7 @@ export class TemplatesService {
         job = await this.messageQueue.add('email', {
           accountId: account.id,
           audienceId,
+          cc: template.cc,
           customerId,
           domain: sendingDomain,
           email: sendingEmail,


### PR DESCRIPTION
# Documentation Changes

The second field in the email builder is the CC field, where a list of comma separated emails can be listed that should be sent a carbon copy of an email whenever this template is used. If any of the emails are not valid or the emails are separated by any other delimiter, the template will not be saved correctly.