### PR TITLE
Adding better icon and text for "Actions" of a stopped journey

### DIFF
--- a/packages/client/src/components/TableTemplate/TableTemplate.tsx
+++ b/packages/client/src/components/TableTemplate/TableTemplate.tsx
@@ -5,6 +5,7 @@ import {
   ChevronDownIcon,
   MinusIcon,
   PencilSquareIcon,
+  EllipsisHorizontalCircleIcon,
 } from "@heroicons/react/20/solid";
 import Chip from "components/Elements/Chip";
 import { Menu, Transition } from "@headlessui/react";
@@ -921,7 +922,11 @@ export default function TableTemplate<T extends TableDataItem>({
       return isButton ? (
         <Menu as="div" className="relative">
           <Menu.Button className="outline-none">
-            <PencilSquareIcon className="text-gray-400 hover:text-gray-500 ml-[10px] text-[16px] w-[24px]" />
+            {row.isStopped ? (
+              <EllipsisHorizontalCircleIcon className="text-gray-400 hover:text-gray-500 ml-[10px] text-[16px] w-[24px]" />
+            ) : (
+              <PencilSquareIcon className="text-gray-400 hover:text-gray-500 ml-[10px] text-[16px] w-[24px]" />
+            )}
           </Menu.Button>
           <Transition
             as={Fragment}
@@ -938,7 +943,9 @@ export default function TableTemplate<T extends TableDataItem>({
                   className="!no-underline"
                   href={`flow/${row.id}${row.isActive ? "/view" : ""}`}
                 >
-                  <div className="w-full">Edit</div>
+                  <div className="w-full">
+                    {row.isStopped ? "View" : "Edit"}
+                  </div>
                 </Link>,
                 <button
                   onClick={async () => {

--- a/packages/client/src/components/TableTemplate/TableTemplate.tsx
+++ b/packages/client/src/components/TableTemplate/TableTemplate.tsx
@@ -922,7 +922,7 @@ export default function TableTemplate<T extends TableDataItem>({
       return isButton ? (
         <Menu as="div" className="relative">
           <Menu.Button className="outline-none">
-            {row.isStopped ? (
+            {row.isStopped || row.isActive ? (
               <EllipsisHorizontalCircleIcon className="text-gray-400 hover:text-gray-500 ml-[10px] text-[16px] w-[24px]" />
             ) : (
               <PencilSquareIcon className="text-gray-400 hover:text-gray-500 ml-[10px] text-[16px] w-[24px]" />
@@ -944,7 +944,7 @@ export default function TableTemplate<T extends TableDataItem>({
                   href={`flow/${row.id}${row.isActive ? "/view" : ""}`}
                 >
                   <div className="w-full">
-                    {row.isStopped ? "View" : "Edit"}
+                    {row.isStopped || row.isActive ? "View" : "Edit"}
                   </div>
                 </Link>,
                 <button


### PR DESCRIPTION
Fixes #126 
- Adds a different icon to show it's not editable.
- Changes text to "View" in dropdown menu
Screenshot of new icon + "View" text:
<img width="1179" alt="Screen Shot 2023-04-05 at 4 06 39 PM" src="https://user-images.githubusercontent.com/129563453/230268438-dcbf5f02-2825-4c10-878a-99c5c9815299.png">
