### PR TITLE
Fix parsing handling of change stream

### DIFF
--- a/packages/server/src/api/customers/customers.consumer.ts
+++ b/packages/server/src/api/customers/customers.consumer.ts
@@ -59,9 +59,10 @@ export class CustomersConsumerService implements OnApplicationBootstrap {
     return async (changeMessage: EachMessagePayload) => {
       try {
         let messStr = changeMessage.message.value.toString();
-        let message: ChangeStreamDocument<Customer> = JSON.parse(
-          JSON.parse(messStr)
-        ); //double parse because single parses it to just string ?? TODO_JH figure out why that's the case
+        let message: ChangeStreamDocument<Customer> = JSON.parse(messStr);
+        if (typeof message === 'string') {
+          message = JSON.parse(message); //double parse if kafka record is published as string not object
+        }
         const session = randomUUID();
         let account: Account;
         let customer: CustomerDocument;


### PR DESCRIPTION
Fixes: 

```
[2023-12-14 06:22:05.135 PM] [error]: 	Something went wrong processing mongo change stream message {"_id": {"_data": "82657B47CC0000001C2B022C0100296E5A10042FB2FFEF4C13458993E86216DCD1D8C846645F696400646570C823261A2400760A76E20004"}, "operationType": "replace", "clusterTime": {"$timestamp": {"t": 1702578124, "i": 28}}, "wallTime": {"$date": 1702578124877}, "fullDocument": {"_id": {"$oid": "6570c823261a2400760a76e2"}, "firstName": "Mahamad", "lastName": "Charawi", "email": "mahamad@laudspeaker.com", "workflows": [], "journeys": [], "ownerId": "e848de71-f906-4403-85a7-2d0c5fd7192b", "posthogId": [], "slackTeamId": [], "verified": true, "__v": 0, "createdAt": 1.701890083E12}, "ns": {"db": "test", "coll": "customers"}, "documentKey": {"_id": {"$oid": "6570c823261a2400760a76e2"}}}. {stack: SyntaxError: Unexpected token o in JSON at position 1   
```