### PR TITLE
update deploy to work with eks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,27 @@
 name: Deploy
 on:
   workflow_call:
+    inputs:
+      image-repository:
+        description: Docker image to deploy
+        default: laudspeaker/laudspeaker
+        required: false
+        type: string
+      image-tag:
+        description: Tag of docker image to deploy.
+        default: latest
+        required: true
+        type: string
+      cluster:
+        description: Name of EKS cluster to deploy to
+        default: laudspeaker-staging
+        required: true
+        type: string
+      env:
+        description: Environment to deploy docker. Should match values file in infrastructure repo such that <env>.yaml is a file in deploys/ folder
+        default: staging
+        required: true
+        type: string
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true
@@ -15,6 +36,16 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: us-east-1
     steps:
-      - name: Force redeploy
+      - name: Checkout infra repo
+        uses: actions/checkout@v4
+        with:
+          repository: laudspeaker/infrastructure
+      - name: Setup helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.13.2
+      - name: Build chart and deploy
         run: |
-          aws ecs update-service --cluster staging --service staging --force-new-deployment
+          aws eks update-kubeconfig --name ${{ inputs.cluster }}
+          helm dependency update deploys/charts/laudspeaker/
+          helm upgrade --install -f deploys/values/${{ inputs.env }}.yaml laudspeaker-${{ inputs.env }} deploys/charts/laudspeaker/ --namespace laudspeaker --create-namespace --set image.tag=${{ inputs.image-tag }},image.repository=${{ inputs.image-repository }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: laudspeaker/infrastructure
+          token: ${{ secret.CI_PAT }}
       - name: Setup helm
         uses: azure/setup-helm@v3
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: laudspeaker/infrastructure
-          token: ${{ secret.CI_PAT }}
+          token: ${{ secrets.CI_PAT }}
       - name: Setup helm
         uses: azure/setup-helm@v3
         with:

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -41,4 +41,9 @@ jobs:
     needs: [setup, push-staging]
     name: Redeploy staging
     uses: ./.github/workflows/deploy.yml
+    with:
+      image-repository: laudspeaker/laudspeaker
+      image-tag: ${{ needs.setup.outputs.short_sha }}
+      cluster: laudspeaker-staging
+      env: staging
     secrets: inherit

--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -9,7 +9,8 @@ on:
         type: string
 jobs:
   deploy-staging:
-    uses: ./.github/workflows/deploy.yaml
+    name: Redeploy staging
+    uses: ./.github/workflows/deploy.yml
     with:
       image-repository: laudspeaker/laudspeaker
       image-tag: ${{ inputs.tag }}

--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -1,0 +1,18 @@
+name: Trigger staging deploy
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Tag of laudspeaker/laudspeaker image to deploy
+        required: false
+        default: latest
+        type: string
+jobs:
+  deploy-staging:
+    uses: ./.github/workflows/deploy.yaml
+    with:
+      image-repository: laudspeaker/laudspeaker
+      image-tag: ${{ inputs.tag }}
+      cluster: laudspeaker-staging
+      env: staging
+    secrets: inherit


### PR DESCRIPTION
### Work required alongside this PR

1. Likely the checkout action will fail in the deploy action because it doesn't have the access to read the infrastructure repository. We'll have to setup a SSH token or a github token that has access to pull the laudspeaker/infrastructure repository and then add it to the parameters passed here: https://github.com/laudspeaker/laudspeaker/pull/260/files#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R42.
2. Testing of deploy is hard to do locally so fixing any issues with how helm is setup or how we configure the kubeconfig before helm deploy
3. We'll have to setup DNS certs for the load balancer. We should walk through this together because uncertain if we can re-deploy the load balancer with the updated certificate or if we'll need to redeploy the cluster.
4. I believe the staging postgres instance has networking configurations that's preventing us from connecting, so we'll have to work through those together.