### PR TITLE
Fix transition processor to check DB after template cache miss

### DIFF
--- a/packages/server/src/api/steps/processors/transition.processor.ts
+++ b/packages/server/src/api/steps/processors/transition.processor.ts
@@ -703,6 +703,17 @@ export class TransitionProcessor extends WorkerHost {
       `template:${step.metadata.template}`
     );
 
+    if (!template) {
+      template = await this.templatesService.lazyFindByID(
+        step.metadata.template
+      );
+      await this.cacheManager.set(
+        `template:${step.metadata.destination}`,
+        template,
+        5000
+      );
+    }
+
     if (
       messageSendType === 'SEND' &&
       process.env.MOCK_MESSAGE_SEND === 'true' &&


### PR DESCRIPTION
The transition processor looks up a template in the cache but doesn't look it up in the DB after a cache miss, this PR fixes that bug.