### PR TITLE
handleMessage should check if step.metadata.destination is set before using it for cache key

### DIFF
--- a/packages/server/src/api/steps/processors/transition.processor.ts
+++ b/packages/server/src/api/steps/processors/transition.processor.ts
@@ -1099,17 +1099,21 @@ export class TransitionProcessor extends WorkerHost {
       return;
     }
 
-    let nextStep: Step = await this.cacheManager.get(
-      `step:${step.metadata.destination}`
-    );
-    if (!nextStep) {
-      nextStep = await this.stepsService.lazyFindByID(
-        step.metadata.destination
+    let nextStep: Step;
+
+    if(step.metadata.destination) {
+      nextStep = await this.cacheManager.get(
+        `step:${step.metadata.destination}`
       );
-      await this.cacheManager.set(
-        `step:${step.metadata.destination}`,
-        nextStep
-      );
+      if (!nextStep) {
+        nextStep = await this.stepsService.lazyFindByID(
+          step.metadata.destination
+        );
+        await this.cacheManager.set(
+          `step:${step.metadata.destination}`,
+          nextStep
+        );
+      }
     }
 
     if (nextStep) {


### PR DESCRIPTION
`handleMessage` assumes all message steps will have a destination. It uses `step.metada.destination` to check if the nextStep has been cached. This PR fixes ensures that it properly checks if there is a destination before using it for a cache key