### PR TITLE
updated start:debug for server's package.json to use .env file

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -9,7 +9,7 @@
     "start": "nest start",
     "start:dev": "env-cmd -f .env npm run prebuild && env-cmd -f .env nest start --watch",
     "start:dev:db": "./src/common/scripts/start-db.sh",
-    "start:debug": "npm run prebuild && nest start --debug --watch",
+    "start:debug": "env-cmd -f .env npm run prebuild && env-cmd -f .env nest start --debug --watch",
     "start:prod": "env-cmd -f .env  node dist/src/main.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\"",
     "lint:fix": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",


### PR DESCRIPTION
This PR fixes the command `npm run start:debug` for the backend server to use the .env file