### PR TITLE
handleMessage cache template with the correct key

### DIFF
--- a/packages/server/src/api/steps/processors/transition.processor.ts
+++ b/packages/server/src/api/steps/processors/transition.processor.ts
@@ -728,7 +728,7 @@ export class TransitionProcessor extends WorkerHost {
         step.metadata.template
       );
       await this.cacheManager.set(
-        `template:${step.metadata.destination}`,
+        `template:${step.metadata.template}`,
         template,
         5000
       );


### PR DESCRIPTION
Use `step.metadata.template` to cache the template instead of `step.metadata.destination`