### PR TITLE
events preprocessor caches journeys

### DIFF
--- a/packages/server/src/api/events/events.preprocessor.ts
+++ b/packages/server/src/api/events/events.preprocessor.ts
@@ -33,6 +33,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Account } from '../accounts/entities/accounts.entity';
 import { Workspaces } from '../workspaces/entities/workspaces.entity';
 import { EventsService } from './events.service';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
 
 export enum ProviderType {
   LAUDSPEAKER = 'laudspeaker',
@@ -79,7 +81,8 @@ export class EventsPreProcessor extends WorkerHost {
     @InjectModel(Customer.name) public customerModel: Model<CustomerDocument>,
     @InjectQueue('events') private readonly eventsQueue: Queue,
     @InjectRepository(Journey)
-    private readonly journeysRepository: Repository<Journey>
+    private readonly journeysRepository: Repository<Journey>,
+    @Inject(CACHE_MANAGER) private cacheManager: Cache
   ) {
     super();
   }

--- a/packages/server/src/api/journeys/journeys.service.ts
+++ b/packages/server/src/api/journeys/journeys.service.ts
@@ -1626,6 +1626,11 @@ export class JourneysService {
       });
 
       await this.trackChange(account, journeyResult.id);
+
+      // invalidate journeys cache entry set in eventPreprocessor
+      if(workspace) {
+        await this.cacheManager.del(`journeys:${workspace.id}`);
+      }
     } catch (err) {
       this.error(err, this.stop.name, session, account.email);
       throw err;

--- a/packages/server/src/api/journeys/journeys.service.ts
+++ b/packages/server/src/api/journeys/journeys.service.ts
@@ -83,6 +83,8 @@ import { RedisService } from '@liaoliaots/nestjs-redis';
 import { JourneyChange } from './entities/journey-change.entity';
 import isObjectDeepEqual from '@/utils/isObjectDeepEqual';
 import { JourneyLocation } from './entities/journey-location.entity';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
 
 export enum JourneyStatus {
   ACTIVE = 'Active',
@@ -247,7 +249,8 @@ export class JourneysService {
     private readonly journeyLocationsService: JourneyLocationsService,
     @InjectQueue('transition') private readonly transitionQueue: Queue,
     @Inject(RedisService) private redisService: RedisService,
-    @InjectQueue('enrollment') private readonly enrollmentQueue: Queue
+    @InjectQueue('enrollment') private readonly enrollmentQueue: Queue,
+    @Inject(CACHE_MANAGER) private cacheManager: Cache
   ) {}
 
   log(message, method, session, user = 'ANONYMOUS') {
@@ -1502,6 +1505,11 @@ export class JourneysService {
 
       if (!journey.inclusionCriteria)
         throw new Error('To start journey a filter should be defined');
+
+      // invalidate journeys cache entry set in eventPreprocessor
+      if(workspace) {
+        await this.cacheManager.del(`journeys:${workspace.id}`);
+      }
 
       const graph = new Graph();
       const steps = await this.stepsService.transactionalfindByJourneyID(

--- a/packages/server/src/api/journeys/journeys.service.ts
+++ b/packages/server/src/api/journeys/journeys.service.ts
@@ -1411,6 +1411,12 @@ export class JourneysService {
         }
       );
       await this.trackChange(account, id);
+
+      // invalidate journeys cache entry set in eventPreprocessor
+      if(workspace) {
+        await this.cacheManager.del(`journeys:${workspace.id}`);
+      }
+
       return result;
     } catch (err) {
       this.error(err, this.markDeleted.name, session, account.email);
@@ -1460,6 +1466,11 @@ export class JourneysService {
 
       await this.trackChange(account, journeyResult.id);
 
+      // invalidate journeys cache entry set in eventPreprocessor
+      if(workspace) {
+        await this.cacheManager.del(`journeys:${workspace.id}`);
+      }
+      
       return journeyResult;
     } catch (error) {
       this.error(error, this.setPaused.name, session, account.email);


### PR DESCRIPTION
Event preprocessor now caches active journey collection so we don't have to hit the DB. the journey collection cache entry will be invalidated when a journey is started, paused or deleted