### PR TITLE
created web/queue/cron process types

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,5 +79,6 @@ COPY ./scripts /app/scripts/
 #Expose web port
 EXPOSE 80
 
-# Run migrations and serve app
-CMD ["sh", "-c", "SENTRY_RELEASE=$(cat SENTRY_RELEASE) && ./scripts/setup_config.sh && clickhouse-migrations migrate && typeorm-ts-node-commonjs migration:run -d packages/server/src/data-source.ts && node dist/src/main.js"]
+COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,4 +81,6 @@ EXPOSE 80
 
 COPY docker-entrypoint.sh /app/docker-entrypoint.sh
 
+RUN ["chmod", "+x", "/app/docker-entrypoint.sh"]
+
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -186,11 +186,11 @@ services:
     networks:
       - laudspeaker_default
 
-  laudspeaker:
+  laudspeaker-web:
     profiles:
       - "testing"
     image: ${LAUDSPEAKER_IMAGE:-laudspeaker/laudspeaker:latest}
-    container_name: laudspeaker
+    container_name: laudspeaker-web
     ports:
       - "8080:8080"
     healthcheck:
@@ -208,10 +208,53 @@ services:
     networks:
       - laudspeaker_default
 
+  laudspeaker-queue:
+    profiles:
+      - "testing"
+    image: ${LAUDSPEAKER_IMAGE:-laudspeaker/laudspeaker:latest}
+    container_name: laudspeaker-queue
+    command: "queue"
+    # ports:
+    #   - "8080:8080"
+    # healthcheck:
+    #   test: ["CMD", "curl", "-f", "localhost:8080"]
+    #   interval: 5s
+    #   timeout: 30s
+    #   retries: 20
+    depends_on:
+      laudspeaker-web:
+        condition: service_healthy
+    env_file:
+      - ./local-env/env-docker-compose
+    networks:
+      - laudspeaker_default
+
+  laudspeaker-cron:
+    profiles:
+      - "testing"
+    image: ${LAUDSPEAKER_IMAGE:-laudspeaker/laudspeaker:latest}
+    container_name: laudspeaker-cron
+    command: "cron"
+    # ports:
+    #   - "8080:8080"
+    # healthcheck:
+    #   test: ["CMD", "curl", "-f", "localhost:8080"]
+    #   interval: 5s
+    #   timeout: 30s
+    #   retries: 20
+    depends_on:
+      laudspeaker-web:
+        condition: service_healthy
+    env_file:
+      - ./local-env/env-docker-compose
+    networks:
+      - laudspeaker_default
+
   s3-createbuckets:
     image: minio/mc
     profiles:
       - "testing"
+      - gui
     depends_on:
       s3:
         condition: service_healthy
@@ -235,7 +278,7 @@ services:
     profiles:
       - testing
     depends_on:
-      laudspeaker:
+      laudspeaker-web:
         condition: service_healthy
     networks:
       - laudspeaker_default

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+export SENTRY_RELEASE=$(cat SENTRY_RELEASE)
+
+# Web server runs first. All other process types are dependant on the web server container
+if [[ "$1" = 'web' || -z "$1" ]]; then
+	export LAUDSPEAKER_PROCESS_TYPE="WEB"
+
+	echo "Running setup_config.sh"
+	bash ./scripts/setup_config.sh
+
+	echo "Running clickhouse-migrations"
+	clickhouse-migrations migrate
+
+	echo "Running Typeorm migrations"
+	typeorm-ts-node-commonjs migration:run -d packages/server/src/data-source.ts
+fi
+
+if [[ "$1" = 'queue' ]]; then
+	export LAUDSPEAKER_PROCESS_TYPE="QUEUE"
+fi
+
+if [[ "$1" = 'cron' ]]; then
+	export LAUDSPEAKER_PROCESS_TYPE="CRON"
+fi
+
+echo "Starting LaudSpeaker Process: $LAUDSPEAKER_PROCESS_TYPE"
+node dist/src/main.js

--- a/packages/server/src/api/customers/customers.module.ts
+++ b/packages/server/src/api/customers/customers.module.ts
@@ -30,6 +30,26 @@ import { SegmentsService } from '../segments/segments.service';
 import { Segment } from '../segments/entities/segment.entity';
 import { SegmentCustomers } from '../segments/entities/segment-customers.entity';
 
+function getProvidersList() {
+  let providerList: Array<any> = [
+    CustomersService,
+    AudiencesHelper,
+    CustomersConsumerService,
+    S3Service,
+    JourneyLocationsService,
+  ];
+
+  if (process.env.LAUDSPEAKER_PROCESS_TYPE == "QUEUE") {
+    providerList = [
+      ...providerList,
+      CustomersProcessor,
+      ImportProcessor,
+    ];
+  }
+
+  return providerList;
+}
+
 @Module({
   imports: [
     MongooseModule.forFeature([
@@ -64,16 +84,7 @@ import { SegmentCustomers } from '../segments/entities/segment-customers.entity'
     JourneysModule,
   ],
   controllers: [CustomersController],
-  providers: [
-    CustomersService,
-    CustomersProcessor,
-    AudiencesHelper,
-    CustomersConsumerService,
-    S3Service,
-    ImportProcessor,
-    JourneyLocationsService,
-  ],
-
+  providers: getProvidersList(),
   exports: [CustomersService, CustomersConsumerService],
 })
 export class CustomersModule {}

--- a/packages/server/src/api/email/email.module.ts
+++ b/packages/server/src/api/email/email.module.ts
@@ -14,6 +14,20 @@ import {
 import { CustomersModule } from '../customers/customers.module';
 import { WebhooksModule } from '../webhooks/webhooks.module';
 
+function getProvidersList() {
+  let providerList: Array<any> = [
+  ];
+
+  if (process.env.LAUDSPEAKER_PROCESS_TYPE == "QUEUE") {
+    providerList = [
+      ...providerList,
+      MessageProcessor,
+    ];
+  }
+
+  return providerList;
+}
+
 @Module({
   imports: [
     BullModule.registerQueue({
@@ -33,6 +47,6 @@ import { WebhooksModule } from '../webhooks/webhooks.module';
     WebhooksModule,
   ],
   controllers: [EmailController],
-  providers: [MessageProcessor],
+  providers: getProvidersList(),
 })
 export class EmailModule {}

--- a/packages/server/src/api/events/events.module.ts
+++ b/packages/server/src/api/events/events.module.ts
@@ -51,6 +51,28 @@ import { Journey } from '../journeys/entities/journey.entity';
 import { WebhooksModule } from '../webhooks/webhooks.module';
 import { CacheService } from '@/common/services/cache.service';
 
+function getProvidersList() {
+  let providerList: Array<any> = [
+    EventsService,
+    AudiencesHelper,
+    RedlockService,
+    JourneyLocationsService,
+    CustomersService,
+    S3Service,
+    CacheService,
+  ];
+
+  if (process.env.LAUDSPEAKER_PROCESS_TYPE == "QUEUE") {
+    providerList = [
+      ...providerList,
+      EventsProcessor,
+      EventsPreProcessor
+    ];
+  }
+
+  return providerList;
+}
+
 @Module({
   imports: [
     TypeOrmModule.forFeature([
@@ -112,17 +134,7 @@ import { CacheService } from '@/common/services/cache.service';
     forwardRef(() => StepsModule),
   ],
   controllers: [EventsController],
-  providers: [
-    EventsService,
-    EventsProcessor,
-    EventsPreProcessor,
-    AudiencesHelper,
-    RedlockService,
-    JourneyLocationsService,
-    CustomersService,
-    S3Service,
-    CacheService,
-  ],
+  providers: getProvidersList(),
   exports: [EventsService],
 })
 export class EventsModule {}

--- a/packages/server/src/api/integrations/integrations.module.ts
+++ b/packages/server/src/api/integrations/integrations.module.ts
@@ -10,6 +10,21 @@ import { IntegrationsController } from './integrations.controller';
 import { IntegrationsProcessor } from './integrations.processor';
 import { IntegrationsService } from './integrations.service';
 
+function getProvidersList() {
+  let providerList: Array<any> = [
+    IntegrationsService,
+  ];
+
+  if (process.env.LAUDSPEAKER_PROCESS_TYPE == "QUEUE") {
+    providerList = [
+      ...providerList,
+      IntegrationsProcessor,
+    ];
+  }
+
+  return providerList;
+}
+
 @Module({
   imports: [
     AccountsModule,
@@ -22,7 +37,7 @@ import { IntegrationsService } from './integrations.service';
     }),
   ],
   controllers: [IntegrationsController],
-  providers: [IntegrationsService, IntegrationsProcessor],
+  providers: getProvidersList(),
   exports: [IntegrationsService],
 })
 export class IntegrationsModule {}

--- a/packages/server/src/api/slack/slack.module.ts
+++ b/packages/server/src/api/slack/slack.module.ts
@@ -20,6 +20,22 @@ import { Step } from '../steps/entities/step.entity';
 import { KafkaModule } from '../kafka/kafka.module';
 import { Workspaces } from '../workspaces/entities/workspaces.entity';
 
+function getProvidersList() {
+  let providerList: Array<any> = [
+    SlackService,
+    WebhooksService,
+  ];
+
+  if (process.env.LAUDSPEAKER_PROCESS_TYPE == "QUEUE") {
+    providerList = [
+      ...providerList,
+      SlackProcessor,
+    ];
+  }
+
+  return providerList;
+}
+
 @Module({
   imports: [
     BullModule.registerQueue({
@@ -50,7 +66,7 @@ import { Workspaces } from '../workspaces/entities/workspaces.entity';
     KafkaModule,
   ],
   controllers: [SlackController],
-  providers: [SlackProcessor, SlackService, WebhooksService],
+  providers: getProvidersList(),
   exports: [SlackService],
 })
 export class SlackModule {}

--- a/packages/server/src/api/steps/steps.module.ts
+++ b/packages/server/src/api/steps/steps.module.ts
@@ -35,6 +35,27 @@ import { Workspaces } from '../workspaces/entities/workspaces.entity';
 import { Requeue } from './entities/requeue.entity';
 import { CacheService } from '@/common/services/cache.service';
 
+function getProvidersList() {
+  let providerList: Array<any> = [
+    StepsService,
+    JobsService,
+    RedlockService,
+    JourneyLocationsService,
+    CacheService
+  ];
+
+  if (process.env.LAUDSPEAKER_PROCESS_TYPE == "QUEUE") {
+    providerList = [
+      ...providerList,
+      TransitionProcessor,
+      StartProcessor,
+      EnrollmentProcessor
+    ];
+  }
+
+  return providerList;
+}
+
 @Module({
   imports: [
     TypeOrmModule.forFeature([
@@ -73,16 +94,7 @@ import { CacheService } from '@/common/services/cache.service';
     forwardRef(() => JourneysModule),
     SlackModule,
   ],
-  providers: [
-    StepsService,
-    JobsService,
-    TransitionProcessor,
-    StartProcessor,
-    RedlockService,
-    JourneyLocationsService,
-    EnrollmentProcessor,
-    CacheService,
-  ],
+  providers: getProvidersList(),
   controllers: [StepsController],
   exports: [StepsService],
 })

--- a/packages/server/src/api/webhooks/webhooks.module.ts
+++ b/packages/server/src/api/webhooks/webhooks.module.ts
@@ -15,6 +15,21 @@ import { TemplatesModule } from '../templates/templates.module';
 import { Step } from '../steps/entities/step.entity';
 import { KafkaModule } from '../kafka/kafka.module';
 
+function getProvidersList() {
+  let providerList: Array<any> = [
+    WebhooksService,
+  ];
+
+  if (process.env.LAUDSPEAKER_PROCESS_TYPE == "QUEUE") {
+    providerList = [
+      ...providerList,
+      WebhooksProcessor,
+    ];
+  }
+
+  return providerList;
+}
+
 @Module({
   imports: [
     TypeOrmModule.forFeature([Account, Step]),
@@ -27,7 +42,7 @@ import { KafkaModule } from '../kafka/kafka.module';
     TemplatesModule,
     KafkaModule,
   ],
-  providers: [WebhooksService, WebhooksProcessor],
+  providers: getProvidersList(),
   controllers: [WebhooksController],
   exports: [WebhooksService],
 })

--- a/packages/server/src/app.module.ts
+++ b/packages/server/src/app.module.ts
@@ -96,6 +96,22 @@ function redact(obj) {
   return copy;
 }
 
+function getProvidersList() {
+  let providerList: Array<any> = [
+    RedlockService,
+    JourneyLocationsService,
+  ];
+
+  if (process.env.LAUDSPEAKER_PROCESS_TYPE == "CRON") {
+    providerList = [
+      ...providerList,
+      CronService,
+    ];
+  }
+
+  return providerList;
+}
+
 const myFormat = winston.format.printf(function ({
   timestamp,
   context,
@@ -260,7 +276,7 @@ export const formatMongoConnectionString = (mongoConnectionString: string) => {
     OrganizationsModule,
   ],
   controllers: [AppController],
-  providers: [CronService, RedlockService, JourneyLocationsService],
+  providers: getProvidersList(),
 })
 export class AppModule {
   configure(consumer: MiddlewareConsumer) {


### PR DESCRIPTION
Migrated the app to have process types such as web, queue and cron. Migrated modules to load specific providers depending on the `LAUDSPEAKER_PROCESS_TYPE` environment variable set by the new `docker-entrypoint.sh` entrypoint.