### PR TITLE
Use node-foreman for local development

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,4 @@
+web: LAUDSPEAKER_PROCESS_TYPE=WEB npm run start:debug -w packages/server
+queue: LAUDSPEAKER_PROCESS_TYPE=QUEUE npm run start:debug -w packages/server
+cron: LAUDSPEAKER_PROCESS_TYPE=CRON npm run start:debug -w packages/server
+client: npm run start:client

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   redis:
     hostname: redis
@@ -198,6 +197,7 @@ services:
       interval: 5s
       timeout: 30s
       retries: 20
+      start_period: 60s
     depends_on:
       init-environment:
         condition: service_completed_successfully
@@ -322,7 +322,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://localhost:5540/healthcheck || exit 1
+      test: wget --no-verbose --tries=1 --spider http://127.0.0.1:5540/api/health/ || exit 1
     networks:
       - laudspeaker_default
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       ],
       "dependencies": {
         "concurrently": "^7.4.0",
+        "foreman": "^3.0.1",
         "logform": "^2.4.2",
         "luxon": "^3.2.1",
         "p-map": "^5.5.0",
@@ -13722,6 +13723,28 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/foreman": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/foreman/-/foreman-3.0.1.tgz",
+      "integrity": "sha512-ek/qoM0vVKpxzkBUQN9k4Fs7l0XsHv4bqxuEW6oqIS4s0ouYKsQ19YjBzUJKTFRumFiSpUv7jySkrI6lfbhjlw==",
+      "dependencies": {
+        "commander": "^2.15.1",
+        "http-proxy": "^1.17.0",
+        "mustache": "^2.2.1",
+        "shell-quote": "^1.6.1"
+      },
+      "bin": {
+        "nf": "nf.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/foreman/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
     "node_modules/forever-agent": {
       "version": "0.6.1",
       "license": "Apache-2.0",
@@ -19338,6 +19361,17 @@
       },
       "bin": {
         "multicast-dns": "cli.js"
+      }
+    },
+    "node_modules/mustache": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
+      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
       }
     },
     "node_modules/mute-stream": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "license": "MIT",
   "dependencies": {
     "concurrently": "^7.4.0",
+    "foreman": "^3.0.1",
     "logform": "^2.4.2",
     "luxon": "^3.2.1",
     "p-map": "^5.5.0",


### PR DESCRIPTION
This PR adds the package [node-foreman](https://github.com/strongloop/node-foreman) to help with local development.

1. Before starting foreman, add `PORT=3000` to your `.env` file in `packages/client`
2. Start foreman with `npx nf start`. To start more processes of a particular type, you can use `npx nf start web=5` or `npx nf start queue=10,cron=4`
3. The `Procfile` in the root directory is the manifest for spawning different processes

