### PR TITLE
New HealthCheckService to help docker/k8s do healthchecks on all process types

### DIFF
--- a/packages/server/src/app.healthcheck.service.ts
+++ b/packages/server/src/app.healthcheck.service.ts
@@ -1,0 +1,88 @@
+import { Inject, Injectable, LoggerService } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import fs from "fs";
+import { randomUUID } from 'crypto';
+
+@Injectable()
+export class HealthCheckService {
+  constructor(
+    @Inject(WINSTON_MODULE_NEST_PROVIDER)
+    private readonly logger: LoggerService,
+  ) {}
+
+  log(message, method, session, user = 'ANONYMOUS') {
+    this.logger.log(
+      message,
+      JSON.stringify({
+        class: HealthCheckService.name,
+        method: method,
+        session: session,
+        user: user,
+      })
+    );
+  }
+  debug(message, method, session, user = 'ANONYMOUS') {
+    this.logger.debug(
+      message,
+      JSON.stringify({
+        class: HealthCheckService.name,
+        method: method,
+        session: session,
+        user: user,
+      })
+    );
+  }
+  warn(message, method, session, user = 'ANONYMOUS') {
+    this.logger.warn(
+      message,
+      JSON.stringify({
+        class: HealthCheckService.name,
+        method: method,
+        session: session,
+        user: user,
+      })
+    );
+  }
+  error(error, method, session, user = 'ANONYMOUS') {
+    this.logger.error(
+      error.message,
+      error.stack,
+      JSON.stringify({
+        class: HealthCheckService.name,
+        method: method,
+        session: session,
+        cause: error.cause,
+        name: error.name,
+        user: user,
+      })
+    );
+  }
+  verbose(message, method, session, user = 'ANONYMOUS') {
+    this.logger.verbose(
+      message,
+      JSON.stringify({
+        class: HealthCheckService.name,
+        method: method,
+        session: session,
+        user: user,
+      })
+    );
+  }
+
+  @Cron(CronExpression.EVERY_5_SECONDS)
+  async healthCheck() {
+    const processType = (process.env.LAUDSPEAKER_PROCESS_TYPE ?? "WEB").toLowerCase();
+    const fileName = `laudspeaker-healthcheck-${processType}`;
+    const filePath = `/tmp/${fileName}`;
+    const fileContents = `${Date.now().toString()}\n`;
+
+    const session = randomUUID();
+
+    try {
+      fs.writeFileSync(filePath, fileContents);
+    } catch (err) {
+      this.error(err, this.healthCheck.name, session);
+    }
+  }
+}

--- a/packages/server/src/app.module.ts
+++ b/packages/server/src/app.module.ts
@@ -61,6 +61,7 @@ import { OrganizationsModule } from './api/organizations/organizations.module';
 import { OrganizationInvites } from './api/organizations/entities/organization-invites.entity';
 import { redisStore } from 'cache-manager-redis-yet';
 import { CacheModule } from '@nestjs/cache-manager';
+import { HealthCheckService } from './app.healthcheck.service';
 
 const sensitiveKeys = [
   /cookie/i,
@@ -100,6 +101,7 @@ function getProvidersList() {
   let providerList: Array<any> = [
     RedlockService,
     JourneyLocationsService,
+    HealthCheckService
   ];
 
   if (process.env.LAUDSPEAKER_PROCESS_TYPE == "CRON") {


### PR DESCRIPTION
The new `HealthCheckService` creates a file `laudspeaker-healthcheck-{PROCESS_TYPE}` (`laudspeaker-healthcheck-web`, `laudspeaker-healthcheck-queue` and `laudspeaker-healthcheck-cron`) in `/tmp` every 5 seconds. Deployment orchestration tools can check if that file for a specific process type has been updated in the last minute to indicate whether or not the container is healthy.
Currently, the `HealthCheckService` has been added to all process types.