### PR TITLE
Update Github workflow to run unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,13 +30,16 @@ jobs:
         # TODO remove the || true from the below run once https://github.com/docker/compose/pull/11649 is merged allowing init containers to exit 0 with --wait-allow-exit over --wait
         run: |
           LAUDSPEAKER_IMAGE=${{ inputs.image }} docker compose --profile testing up --wait --quiet-pull || true
-      - name: Install cypress dependencies
+      - name: Install unit test dependencies
         run: |
-          npm install -w packages/tests
+          npm install -w packages/server          
       - name: Run unit tests
         # TODO: Existing unit tests need their dependencies mocked. Append fixed spec files as arguments to test:server
         run: |
           npm run test:server -- cache.service.spec
+      - name: Install cypress dependencies
+        run: |
+          npm install -w packages/tests
       - name: Run cypress tests
         run: |
           TESTS_BASE_URL=http://localhost:8080 TESTS_API_BASE_URL=http://localhost:8080/api TESTS_INTERNAL_API_BASE_URL=http://laudspeaker-web:8080/api npm run tests:run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,10 @@ jobs:
       - name: Install cypress dependencies
         run: |
           npm install -w packages/tests
+      - name: Run unit tests
+        # TODO: Existing unit tests need their dependencies mocked. Append fixed spec files as arguments to test:server
+        run: |
+          npm run test:server -- cache.service.spec
       - name: Run cypress tests
         run: |
           TESTS_BASE_URL=http://localhost:8080 TESTS_API_BASE_URL=http://localhost:8080/api TESTS_INTERNAL_API_BASE_URL=http://laudspeaker-web:8080/api npm run tests:run

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\"",
     "lint:fix": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
-    "test": "env-cmd -f .env jest",
+    "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",


### PR DESCRIPTION
For now, this runs the `cache.service` spec tests. Once we mock the dependencies of existing tests, we can run all unit tests