### PR TITLE
Update procfile to run debuggers on different ports

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-web: LAUDSPEAKER_PROCESS_TYPE=WEB npm run start:debug -w packages/server
-queue: LAUDSPEAKER_PROCESS_TYPE=QUEUE npm run start:debug -w packages/server
-cron: LAUDSPEAKER_PROCESS_TYPE=CRON npm run start:debug -w packages/server
+web: LAUDSPEAKER_PROCESS_TYPE=WEB npm run start:local -w packages/server -- --debug=9229 --watch
+queue: LAUDSPEAKER_PROCESS_TYPE=QUEUE npm run start:local:noprebuild -w packages/server -- --debug=9329 --watch
+cron: LAUDSPEAKER_PROCESS_TYPE=CRON npm run start:local:noprebuild -w packages/server -- --debug=9429 --watch
 client: npm run start:client

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,6 +10,8 @@
     "start:dev": "env-cmd -f .env npm run prebuild && env-cmd -f .env nest start --watch",
     "start:dev:db": "./src/common/scripts/start-db.sh",
     "start:debug": "env-cmd -f .env npm run prebuild && env-cmd -f .env nest start --debug --watch",
+    "start:local": "env-cmd -f .env npm run prebuild && env-cmd -f .env nest start",
+    "start:local:noprebuild": "env-cmd -f .env nest start",
     "start:prod": "env-cmd -f .env  node dist/src/main.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\"",
     "lint:fix": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",


### PR DESCRIPTION
Different process types now run the node debugger on different ports:

- Web: Starting port `9229`, other Web threads on ports 9230, 9231, 9232, etc...
- Queue: Starting port `9329`, other Queue threads on ports 9330, 9331, 9332, etc...
- Cron: Starting port `9429`, other Cron threads on ports  9430, 9431, 9342, etc..

For local development, it should be enough to have your remote debugger attach to the following sources:

- `127.0.0.1:9229`
- `127.0.0.1:9230`
- `127.0.0.1:9329`
- `127.0.0.1:9330`
- `127.0.0.1:9429`
- `127.0.0.1:9430`