### PR TITLE
evaluateMessageStatement uses the correct formatted time variable

### DIFF
--- a/packages/server/src/api/customers/customers.service.ts
+++ b/packages/server/src/api/customers/customers.service.ts
@@ -4820,7 +4820,7 @@ export class CustomersService {
       } else if (time && time.comparisonType === 'after' && time.timeAfter) {
         const timeAfter = new Date(time.timeAfter).toISOString();
         const formattedTimeAfter = timeAfter.split('.')[0];
-        sqlQuery += `AND createdAt >= '${timeAfter}' `;
+        sqlQuery += `AND createdAt >= '${formattedTimeAfter}' `;
       }
       this.debug(
         `the final SQL query is:\n ${sqlQuery}`,


### PR DESCRIPTION
Closes #452 