### PR TITLE
messages are inserted directly to clickhouse via async inserts

### DIFF
--- a/packages/server/src/api/email/email.processor.ts
+++ b/packages/server/src/api/email/email.processor.ts
@@ -205,7 +205,7 @@ export class MessageProcessor extends WorkerHost {
         [
           {
             stepId: job.data.stepId,
-            createdAt: new Date().toISOString(),
+            createdAt: new Date(),
             customerId: job.data.customerId,
             event: 'error',
             eventProvider: job.data.eventProvider,
@@ -251,7 +251,7 @@ export class MessageProcessor extends WorkerHost {
             [
               {
                 stepId: job.data.stepId,
-                createdAt: new Date().toISOString(),
+                createdAt: new Date(),
                 customerId: job.data.customerId,
                 event: 'sent',
                 eventProvider: ClickHouseEventProvider.SENDGRID,
@@ -308,7 +308,7 @@ export class MessageProcessor extends WorkerHost {
             [
               {
                 stepId: job.data.stepId,
-                createdAt: new Date().toISOString(),
+                createdAt: new Date(),
                 customerId: job.data.customerId,
                 event: 'sent',
                 eventProvider: ClickHouseEventProvider.MAILGUN,
@@ -385,7 +385,7 @@ export class MessageProcessor extends WorkerHost {
         [
           {
             stepId: job.data.stepId,
-            createdAt: new Date().toISOString(),
+            createdAt: new Date(),
             customerId: job.data.customerId,
             event: 'error',
             eventProvider: ClickHouseEventProvider.TWILIO,
@@ -411,7 +411,7 @@ export class MessageProcessor extends WorkerHost {
         [
           {
             stepId: job.data.stepId,
-            createdAt: new Date().toISOString(),
+            createdAt: new Date(),
             customerId: job.data.customerId,
             event: 'sent',
             eventProvider: ClickHouseEventProvider.TWILIO,
@@ -488,7 +488,7 @@ export class MessageProcessor extends WorkerHost {
           {
             workspaceId: workspace?.id,
             event: 'error',
-            createdAt: new Date().toISOString(),
+            createdAt: new Date(),
             eventProvider: ClickHouseEventProvider.PUSH,
             messageId: null,
             stepId: job.data.args.stepId,
@@ -546,7 +546,7 @@ export class MessageProcessor extends WorkerHost {
           {
             stepId: job.data.stepId,
             customerId: job.data.customerId,
-            createdAt: new Date().toISOString(),
+            createdAt: new Date(),
             event: 'sent',
             eventProvider: ClickHouseEventProvider.PUSH,
             messageId: messageId,

--- a/packages/server/src/api/events/events.service.ts
+++ b/packages/server/src/api/events/events.service.ts
@@ -1196,7 +1196,7 @@ export class EventsService {
               event: thisEvent.event === '$delivered' ? 'delivered' : 'opened',
               eventProvider: ClickHouseEventProvider.PUSH,
               processed: false,
-              createdAt: new Date().toISOString(),
+              createdAt: new Date(),
             };
             await this.webhooksService.insertMessageStatusToClickhouse(
               [clickHouseRecord],

--- a/packages/server/src/api/slack/slack.module.ts
+++ b/packages/server/src/api/slack/slack.module.ts
@@ -17,7 +17,6 @@ import {
 import { CustomersModule } from '../customers/customers.module';
 import { WebhooksService } from '../webhooks/webhooks.service';
 import { Step } from '../steps/entities/step.entity';
-import { KafkaModule } from '../kafka/kafka.module';
 import { Workspaces } from '../workspaces/entities/workspaces.entity';
 
 function getProvidersList() {
@@ -57,7 +56,6 @@ function getProvidersList() {
       { name: CustomerKeys.name, schema: CustomerKeysSchema },
     ]),
     forwardRef(() => CustomersModule),
-    KafkaModule,
   ],
   controllers: [SlackController],
   providers: getProvidersList(),

--- a/packages/server/src/api/slack/slack.processor.ts
+++ b/packages/server/src/api/slack/slack.processor.ts
@@ -54,7 +54,7 @@ export class SlackProcessor extends WorkerHost {
             {
               workspaceId: workspace?.id,
               event: 'error',
-              createdAt: new Date().toISOString(),
+              createdAt: new Date(),
               eventProvider: ClickHouseEventProvider.SLACK,
               messageId: '',
               stepId: job.data.args.stepId,

--- a/packages/server/src/api/steps/processors/message.step.processor.ts
+++ b/packages/server/src/api/steps/processors/message.step.processor.ts
@@ -588,7 +588,7 @@ export class MessageStepProcessor extends WorkerHost {
             [
               {
                 stepId: job.data.step.id,
-                createdAt: new Date().toISOString(),
+                createdAt: new Date(),
                 customerId: job.data.customer._id,
                 event: 'aborted',
                 eventProvider: ClickHouseEventProvider.TRACKER,
@@ -624,7 +624,7 @@ export class MessageStepProcessor extends WorkerHost {
             [
               {
                 stepId: job.data.step.id,
-                createdAt: new Date().toISOString(),
+                createdAt: new Date(),
                 customerId: job.data.customer._id,
                 event: 'sent',
                 eventProvider: ClickHouseEventProvider.TRACKER,

--- a/packages/server/src/api/steps/processors/transition.processor.ts
+++ b/packages/server/src/api/steps/processors/transition.processor.ts
@@ -487,7 +487,7 @@ export class TransitionProcessor extends WorkerHost {
       [
         {
           stepId: stepID,
-          createdAt: new Date().toISOString(),
+          createdAt: new Date(),
           customerId: customerID,
           event: 'sent',
           eventProvider: ClickHouseEventProvider.TRACKER,
@@ -516,7 +516,7 @@ export class TransitionProcessor extends WorkerHost {
         [
           {
             stepId: stepID,
-            createdAt: new Date().toISOString(),
+            createdAt: new Date(),
             customerId: customerID,
             event: 'delivered',
             eventProvider: ClickHouseEventProvider.TRACKER,
@@ -1057,7 +1057,7 @@ export class TransitionProcessor extends WorkerHost {
         [
           {
             stepId: step.id,
-            createdAt: new Date().toISOString(),
+            createdAt: new Date(),
             customerId: customer._id,
             event: 'aborted',
             eventProvider: ClickHouseEventProvider.TRACKER,
@@ -1099,7 +1099,7 @@ export class TransitionProcessor extends WorkerHost {
         [
           {
             stepId: step.id,
-            createdAt: new Date().toISOString(),
+            createdAt: new Date(),
             customerId: customer._id,
             event: 'sent',
             eventProvider: ClickHouseEventProvider.TRACKER,

--- a/packages/server/src/api/steps/types/messagesender.class.ts
+++ b/packages/server/src/api/steps/types/messagesender.class.ts
@@ -299,7 +299,7 @@ export class MessageSender {
       return [
         {
           stepId: stepID,
-          createdAt: new Date().toISOString(),
+          createdAt: new Date(),
           customerId: customerID,
           event: 'error',
           eventProvider: eventProvider,
@@ -349,7 +349,7 @@ export class MessageSender {
         ret = [
           {
             stepId: stepID,
-            createdAt: new Date().toISOString(),
+            createdAt: new Date(),
             customerId: customerID,
             event: 'sent',
             eventProvider: ClickHouseEventProvider.SENDGRID,
@@ -402,7 +402,7 @@ export class MessageSender {
         ret = [
           {
             stepId: stepID,
-            createdAt: new Date().toISOString(),
+            createdAt: new Date(),
             customerId: customerID,
             event: 'sent',
             eventProvider: ClickHouseEventProvider.RESEND,
@@ -443,7 +443,7 @@ export class MessageSender {
         ret = [
           {
             stepId: stepID,
-            createdAt: new Date().toISOString(),
+            createdAt: new Date(),
             customerId: customerID,
             event: 'sent',
             eventProvider: ClickHouseEventProvider.MAILGUN,
@@ -525,7 +525,7 @@ export class MessageSender {
       return [
         {
           stepId: stepID,
-          createdAt: new Date().toISOString(),
+          createdAt: new Date(),
           customerId: customerID,
           event: 'error',
           eventProvider: ClickHouseEventProvider.TWILIO,
@@ -558,7 +558,7 @@ export class MessageSender {
     ret = [
       {
         stepId: stepID,
-        createdAt: new Date().toISOString(),
+        createdAt: new Date(),
         customerId: customerID,
         event: 'sent',
         eventProvider: ClickHouseEventProvider.TWILIO,
@@ -641,7 +641,7 @@ export class MessageSender {
         {
           workspaceId: workspace.id,
           event: 'error',
-          createdAt: new Date().toISOString(),
+          createdAt: new Date(),
           eventProvider: ClickHouseEventProvider.PUSH,
           messageId: null,
           stepId: stepID,
@@ -667,7 +667,7 @@ export class MessageSender {
           {
             workspaceId: workspace.id,
             event: 'error',
-            createdAt: new Date().toISOString(),
+            createdAt: new Date(),
             eventProvider: ClickHouseEventProvider.PUSH,
             messageId: null,
             stepId: stepID,
@@ -745,7 +745,7 @@ export class MessageSender {
       {
         stepId: stepID,
         customerId: customerID,
-        createdAt: new Date().toISOString(),
+        createdAt: new Date(),
         event: 'sent',
         eventProvider: ClickHouseEventProvider.PUSH,
         messageId: messageId,
@@ -825,7 +825,7 @@ export class MessageSender {
         {
           workspaceId: workspace.id,
           event: 'error',
-          createdAt: new Date().toISOString(),
+          createdAt: new Date(),
           eventProvider: ClickHouseEventProvider.PUSH,
           messageId: null,
           stepId: stepID,
@@ -851,7 +851,7 @@ export class MessageSender {
           {
             workspaceId: workspace.id,
             event: 'error',
-            createdAt: new Date().toISOString(),
+            createdAt: new Date(),
             eventProvider: ClickHouseEventProvider.PUSH,
             messageId: null,
             stepId: stepID,
@@ -925,7 +925,7 @@ export class MessageSender {
       {
         stepId: stepID,
         customerId: customerID,
-        createdAt: new Date().toISOString(),
+        createdAt: new Date(),
         event: 'sent',
         eventProvider: ClickHouseEventProvider.PUSH,
         messageId: messageId,
@@ -988,7 +988,7 @@ export class MessageSender {
         {
           workspaceId: workspace.id,
           event: 'sent',
-          createdAt: new Date().toISOString(),
+          createdAt: new Date(),
           eventProvider: ClickHouseEventProvider.SLACK,
           messageId: String(message.ts),
           stepId: stepID,
@@ -1002,7 +1002,7 @@ export class MessageSender {
         {
           workspaceId: workspace.id,
           event: 'error',
-          createdAt: new Date().toISOString(),
+          createdAt: new Date(),
           eventProvider: ClickHouseEventProvider.SLACK,
           messageId: '',
           stepId: stepID,
@@ -1101,7 +1101,7 @@ export class MessageSender {
   //       await this.webhooksService.insertMessageStatusToClickhouse([
   //         {
   //           event: 'error',
-  //           createdAt: new Date().toISOString(),
+  //           createdAt: new Date(),
   //           eventProvider: ClickHouseEventProvider.WEBHOOKS,
   //           messageId: '',
   //           audienceId: job.data.audienceId,
@@ -1119,7 +1119,7 @@ export class MessageSender {
   //       await this.webhooksService.insertMessageStatusToClickhouse([
   //         {
   //           event: 'sent',
-  //           createdAt: new Date().toISOString(),
+  //           createdAt: new Date(),
   //           eventProvider: ClickHouseEventProvider.WEBHOOKS,
   //           messageId: '',
   //           audienceId: job.data.audienceId,

--- a/packages/server/src/api/webhooks/webhooks.module.ts
+++ b/packages/server/src/api/webhooks/webhooks.module.ts
@@ -13,7 +13,6 @@ import { WebhooksProcessor } from './webhooks.processor';
 import { BullModule } from '@nestjs/bullmq';
 import { TemplatesModule } from '../templates/templates.module';
 import { Step } from '../steps/entities/step.entity';
-import { KafkaModule } from '../kafka/kafka.module';
 
 function getProvidersList() {
   let providerList: Array<any> = [WebhooksService];
@@ -35,7 +34,6 @@ function getProvidersList() {
       name: '{events_pre}',
     }),
     TemplatesModule,
-    KafkaModule,
   ],
   providers: getProvidersList(),
   controllers: [WebhooksController],

--- a/packages/server/src/api/webhooks/webhooks.processor.ts
+++ b/packages/server/src/api/webhooks/webhooks.processor.ts
@@ -265,7 +265,7 @@ export class WebhooksProcessor extends WorkerHost {
           [
             {
               event: 'error',
-              createdAt: new Date().toISOString(),
+              createdAt: new Date(),
               eventProvider: ClickHouseEventProvider.WEBHOOKS,
               messageId: '',
               stepId: job.data.stepId,
@@ -288,7 +288,7 @@ export class WebhooksProcessor extends WorkerHost {
           [
             {
               event: 'sent',
-              createdAt: new Date().toISOString(),
+              createdAt: new Date(),
               eventProvider: ClickHouseEventProvider.WEBHOOKS,
               messageId: '',
               stepId: job.data.stepId,

--- a/packages/server/src/websockets/websocket.gateway.ts
+++ b/packages/server/src/websockets/websocket.gateway.ts
@@ -414,7 +414,7 @@ export class WebsocketGateway implements OnGatewayConnection {
           [
             {
               stepId: customer.customComponents[key].step,
-              createdAt: new Date().toISOString(),
+              createdAt: new Date(),
               customerId: customer.id,
               event: 'delivered',
               eventProvider: ClickHouseEventProvider.TRACKER,


### PR DESCRIPTION
Async inserts are used in favor of Kafka to buffer inserts to the `message_status` table. New environment variables have been added to control how much clickhouse should buffer before inserting into the table:
1. `CLICKHOUSE_MESSAGE_STATUS_ASYNC_MAX_SIZE`. default: `1000000`
2. `CLICKHOUSE_MESSAGE_STATUS_ASYNC_TIMEOUT_MS`. default: `1000`