### PR TITLE
fix customer change processor to not use JSON.parse too many times

### DIFF
--- a/packages/server/src/api/customers/processors/customers.processor.ts
+++ b/packages/server/src/api/customers/processors/customers.processor.ts
@@ -176,13 +176,13 @@ export class CustomerChangeProcessor extends WorkerHost {
     const clientSession = await this.connection.startSession();
     await clientSession.startTransaction();
     try {
-      const messObj = JSON.parse(
-        Buffer.from(job.data.changeMessage.message.value).toString()
-      );
-      let message: ChangeStreamDocument<Customer> = JSON.parse(messObj);
-      if (typeof message === 'string') {
-        message = JSON.parse(message); //double parse if kafka record is published as string not object
+      let message: ChangeStreamDocument<Customer> | String = Buffer.from(job.data.changeMessage.message.value).toString();
+
+      // keep parsing until the kafka payload is turned into an object
+      while(typeof message === 'string' || message instanceof String) {
+        message = JSON.parse(message.toString());
       }
+
       let account: Account;
       let customer: CustomerDocument;
       switch (message.operationType) {


### PR DESCRIPTION
The kafka connector for Mongo may return strings that are not JSON strings nested as expected, especially in mongo 5 on cluster mode. This fixes the error `SyntaxError: Unexpected token o in JSON at position 1`