### PR TITLE
UI fetches templates from server with a specific type

### DIFF
--- a/packages/client/src/pages/FlowBuilderv2/SidePanel/settings/MessageSettings.tsx
+++ b/packages/client/src/pages/FlowBuilderv2/SidePanel/settings/MessageSettings.tsx
@@ -78,13 +78,10 @@ const MessageSettings: FC<SidePanelComponentProps<MessageNodeData>> = ({
 
   const getAllTemplates = async () => {
     const { data: templates } = await ApiService.get<{ data: Template[] }>({
-      url: `${ApiConfig.getAllTemplates}`,
+      url: `${ApiConfig.getAllTemplates}?type=${templateType}`,
     });
 
-    const filteredTemplates = templates?.data?.filter(
-      (item: { type?: string }) => item.type === templateType
-    );
-    setTemplateList(filteredTemplates);
+    setTemplateList(templates?.data);
   };
 
   const handleTemplateInlineEdit = () => {


### PR DESCRIPTION
This fixes the UI so it fetches specific template types (email, webhook, push) from the server instead of fetching all templates and filtering on the client side