### PR TITLE
fix for entry tab of live journey for segments rendering

### DIFF
--- a/packages/client/src/pages/FlowBuilderv2/FlowBuilderSegmentEditor.tsx
+++ b/packages/client/src/pages/FlowBuilderv2/FlowBuilderSegmentEditor.tsx
@@ -38,6 +38,7 @@ import { DateComponent } from "./Elements/DynamicInput";
 import FilterBuilder from "./FilterBuilder/FilterBuilder";
 import { FC } from "react";
 import Button, { ButtonType } from "components/Elements/Buttonv2";
+import FilterViewer from "./FilterViewer/FilterViewer";
 
 const enrollmentTypes = [
   {
@@ -82,6 +83,9 @@ const FlowBuilderSegmentEditor: FC<FlowBuilderSegmentEditorProps> = ({
   const dispatch = useAppDispatch();
 
   if (!journeyEntrySettings) return <></>;
+
+  console.log("in flow seg editor")
+  console.log("seg settings are", segmentsSettings);
 
   return (
     <div className="m-5 max-h-full overflow-y-scroll w-full bg-white rounded p-5 text-[#111827] font-inter">
@@ -452,14 +456,7 @@ const FlowBuilderSegmentEditor: FC<FlowBuilderSegmentEditorProps> = ({
         {segmentsSettings.type === SegmentsSettingsType.CONDITIONAL && (
           <div className="flex flex-col gap-[10px]">
             <div className="font-semibold text-base">Conditions</div>
-            <FilterBuilder
-              settings={segmentsSettings}
-              onSettingsChange={(settings) =>
-                dispatch(
-                  setSegmentsSettings(settings as ConditionalSegmentsSettings)
-                )
-              }
-            />
+            <FilterViewer settingsQuery={segmentsSettings.query}/>
           </div>
         )}
 


### PR DESCRIPTION
<img width="830" alt="Screenshot 2024-06-11 at 7 21 24 PM" src="https://github.com/laudspeaker/laudspeaker/assets/7728266/6a3d720f-5a58-4b19-a3ab-436d3fb544e8">
fix the entry conditions so it renders correctly when live