### PR TITLE
CSV import not longer checks for duplicate customers

### DIFF
--- a/packages/server/src/api/customers/customers.service.ts
+++ b/packages/server/src/api/customers/customers.service.ts
@@ -6324,34 +6324,6 @@ export class CustomersService {
         );
       }
 
-      const docs = await this.CustomerModel.aggregate([
-        {
-          $match: {
-            workspaceId: workspace.id,
-            isAnonymous: false,
-          },
-        },
-        {
-          $group: {
-            _id: `$${passedPK.asAttribute.key}`,
-            count: { $sum: 1 },
-            docs: { $push: '$$ROOT' },
-          },
-        },
-        {
-          $match: {
-            count: { $gt: 1 },
-          },
-        },
-      ]).option({ allowDiskUse: true });
-
-      if (docs?.length) {
-        throw new HttpException(
-          "Selected primary key can't be used cause it's value has duplicates among already existing users.",
-          HttpStatus.BAD_REQUEST
-        );
-      }
-
       const folderPath = 'import-errors';
       const errorFileName = `errors-${fileData.fileKey}.csv`;
       const fullPath = path.join(folderPath, errorFileName);
@@ -6550,34 +6522,6 @@ export class CustomersService {
       ) {
         throw new HttpException(
           'Field selected as primary not corresponding to saved primary Key',
-          HttpStatus.BAD_REQUEST
-        );
-      }
-
-      const docs = await this.CustomerModel.aggregate([
-        {
-          $match: {
-            workspaceId: workspace.id,
-            isAnonymous: false,
-          },
-        },
-        {
-          $group: {
-            _id: `$${passedPK.asAttribute.key}`,
-            count: { $sum: 1 },
-            docs: { $push: '$$ROOT' },
-          },
-        },
-        {
-          $match: {
-            count: { $gt: 1 },
-          },
-        },
-      ]).option({ allowDiskUse: true });
-
-      if (docs?.length) {
-        throw new HttpException(
-          "Selected primary key can't be used cause it's value has duplicates among already existing users.",
           HttpStatus.BAD_REQUEST
         );
       }

--- a/packages/server/src/app.module.ts
+++ b/packages/server/src/app.module.ts
@@ -122,7 +122,7 @@ const myFormat = winston.format.printf(function ({
   try {
     ctx = JSON.parse(context);
   } catch (e) {}
-  return `[${timestamp}] [${level}] [${process.env.LAUDSPEAKER_PROCESS_TYPE}]${
+  return `[${timestamp}] [${level}] [${process.env.LAUDSPEAKER_PROCESS_TYPE}-${process.pid}]${
     ctx?.class ? ' [Class: ' + ctx?.class + ']' : ''
   }${ctx?.method ? ' [Method: ' + ctx?.method + ']' : ''}${
     ctx?.session ? ' [User: ' + ctx?.user + ']' : ''

--- a/packages/server/src/shared/typeorm/typeorm.service.ts
+++ b/packages/server/src/shared/typeorm/typeorm.service.ts
@@ -13,11 +13,10 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
       : 1;
 
     let connectionsPerReplica = Math.floor(totalMaxConnections / maxReplicas);
-    let totalCpuPerReplica = os.cpus().length;
 
     let maxProcessCountPerReplica = process.env.MAX_PROCESS_COUNT_PER_REPLICA
       ? +process.env.MAX_PROCESS_COUNT_PER_REPLICA
-      : totalCpuPerReplica;
+      : 1;
 
     let maxDBConnectionsPerReplicaProcess = Math.floor(
       connectionsPerReplica / maxProcessCountPerReplica
@@ -32,7 +31,6 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
         totalMaxConnections: (${totalMaxConnections}),
         maxReplicas: (${maxReplicas}),
         connectionsPerReplica: (${connectionsPerReplica}),
-        totalCpuPerReplica: (${totalCpuPerReplica}),
         maxProcessCountPerReplica: (${maxProcessCountPerReplica}),
         maxDBConnectionsPerReplicaProcess: (${maxDBConnectionsPerReplicaProcess})`);
 


### PR DESCRIPTION
Since we added unique index on primary keys for customers table, we no longer need to check for duplicates while importing CSV files.
Also added logging to show the PID for each process running to trace bugs, and removed deprecated use of cpu count in typeorm