### PR TITLE
removed the need for CSV importer to query Mongo on each batch

### DIFF
--- a/packages/client/src/pages/PeopleImport/ImportCompletion.tsx
+++ b/packages/client/src/pages/PeopleImport/ImportCompletion.tsx
@@ -27,23 +27,17 @@ const ImportCompletion = ({
     <div className="w-full flex justify-center">
       <div className="py-10 max-w-[800px] w-full">
         <div className="text-[#111827] text-base font-inter font-semibold mb-[10px]">
-          From your file, we can
+          Import Report:
         </div>
         <div className="flex w-full mb-[10px] gap-[10px]">
           <div className="px-[10px] py-1 rounded border border-[#E5E7EB] w-full">
-            <div className="text-[#6B7280] text-sm font-roboto">Create</div>
+            <div className="text-[#6B7280] text-sm font-roboto">Total</div>
             <div className="mt-[10px] text-2xl text-[#111827] font-roboto">
-              {preview?.created}
-            </div>
-          </div>
-          <div className="px-[10px] py-1 rounded border border-[#E5E7EB] w-full">
-            <div className="text-[#6B7280] text-sm font-roboto">Update</div>
-            <div className="mt-[10px] text-2xl text-[#111827] font-roboto">
-              {preview?.updated}
+              {preview?.total}
             </div>
           </div>
           <div className="relative px-[10px] py-1 rounded border border-[#E5E7EB] w-full">
-            <div className="text-[#6B7280] text-sm font-roboto">Skip</div>
+            <div className="text-[#6B7280] text-sm font-roboto">Skipped</div>
             <div className="mt-[10px] text-2xl text-[#111827] font-roboto">
               {preview?.skipped}
             </div>
@@ -52,6 +46,12 @@ const ImportCompletion = ({
                 <CloudArrowDownIcon className="transition-all absolute top-1/2 right-4 p-1 cursor-pointer -translate-y-1/2 w-10 h-10 text-[#111827] hover:text-[#6366F1]" />
               </a>
             )}
+          </div>
+          <div className="px-[10px] py-1 rounded border border-[#E5E7EB] w-full">
+            <div className="text-[#6B7280] text-sm font-roboto">Final</div>
+            <div className="mt-[10px] text-2xl text-[#111827] font-roboto">
+              {preview?.final}
+            </div>
           </div>
         </div>
         {!inSegment && (

--- a/packages/client/src/pages/PeopleImport/PeopleImport.tsx
+++ b/packages/client/src/pages/PeopleImport/PeopleImport.tsx
@@ -62,6 +62,8 @@ enum ValidationError {
 }
 
 export interface PreviewImportResults {
+  total: number;
+  final: number;
   updated: number;
   created: number;
   skipped: number;

--- a/packages/server/src/api/customers/imports.processor.ts
+++ b/packages/server/src/api/customers/imports.processor.ts
@@ -201,7 +201,7 @@ export class ImportProcessor extends WorkerHost {
                 .finally(() => {
                   promiseSet.delete(batchId);
                 });
-              await new Promise((resolve) => setTimeout(resolve, 10000));
+
               batch = [];
               csvStream.resume();
             }


### PR DESCRIPTION
For each batch of customers imported the codebase was checking against mongoDB to get the number of created or updated customers. This PR replaces that by just displaying the totals without the need to query mongo for every batch
![image](https://github.com/laudspeaker/laudspeaker/assets/568368/a8d720d7-4178-4633-a5b5-813c7a871ef1)
