### PR TITLE
Simultaneous processing for Journeys

### DIFF
--- a/packages/server/src/api/events/events.module.ts
+++ b/packages/server/src/api/events/events.module.ts
@@ -60,6 +60,7 @@ import { StartStepProcessor } from '../steps/processors/start.step.processor';
 import { TimeDelayStepProcessor } from '../steps/processors/time.delay.step.processor';
 import { TimeWindowStepProcessor } from '../steps/processors/time.window.step.processor';
 import { OrganizationsModule } from '../organizations/organizations.module';
+import { QueueService } from '@/common/services/queue.service';
 
 function getProvidersList() {
   let providerList: Array<any> = [
@@ -70,6 +71,7 @@ function getProvidersList() {
     CustomersService,
     S3Service,
     CacheService,
+    QueueService
   ];
 
   if (process.env.LAUDSPEAKER_PROCESS_TYPE == 'QUEUE') {

--- a/packages/server/src/api/journeys/journeys.service.ts
+++ b/packages/server/src/api/journeys/journeys.service.ts
@@ -756,8 +756,8 @@ export class JourneysService {
     session: string,
     queryRunner: QueryRunner,
     clientSession?: ClientSession
-  ): Promise<{ name: string; data: any }[]> {
-    const jobs: { name: string; data: any }[] = [];
+  ): Promise<any[]> {
+    const jobsData: any[] = [];
     const step = await this.stepsService.findByJourneyAndType(
       account,
       journey.id,
@@ -778,20 +778,21 @@ export class JourneysService {
       }
     };
     // Prepare a deep copy of the account to modify without affecting the original account object
-  const modifiedAccount = {
-    ...account,
-    teams: account.teams.map(team => ({
-      ...team,
-      organization: {
-        ...team.organization,
-        workspaces: team.organization.workspaces.map(workspace => ({
-          ...workspace,
-          pushConnections: [] //, Clears the pushConnections array
-          //pushPlatforms: null // Clears the pushPlatforms info
-        }))
-      }
-    }))
-  };
+    const modifiedAccount = {
+      ...account,
+      teams: account.teams.map(team => ({
+        ...team,
+        organization: {
+          ...team.organization,
+          workspaces: team.organization.workspaces.map(workspace => ({
+            ...workspace,
+            pushConnections: [] //, Clears the pushConnections array
+            //pushPlatforms: null // Clears the pushPlatforms info
+          }))
+        }
+      }))
+    };
+
     for (const customer of customers) {
       if (
         await this.rateLimitEntryByUniqueEnrolledCustomers(
@@ -808,25 +809,22 @@ export class JourneysService {
         );
         continue;
       }
-      const job = {
-        name: 'start',
-        data: {
-          owner: modifiedAccount,
-          journey: modifiedJourney,
-          step: step,
-          location: locations.find((location: JourneyLocation) => {
-            return (
-              location.customer === (customer._id ?? customer._id.toString()) &&
-              location.journey === journey.id
-            );
-          }),
-          session: session,
-          customer, //customer.id ?? customer._id.toString(),
-        },
+      const jobData = {
+        owner: modifiedAccount,
+        journey: modifiedJourney,
+        step: step,
+        location: locations.find((location: JourneyLocation) => {
+          return (
+            location.customer === (customer._id ?? customer._id.toString()) &&
+            location.journey === journey.id
+          );
+        }),
+        session: session,
+        customer, //customer.id ?? customer._id.toString(),
       };
-      jobs.push(job);
+      jobsData.push(jobData);
     }
-    return jobs;
+    return jobsData;
   }
 
   /**

--- a/packages/server/src/api/journeys/journeys.service.ts
+++ b/packages/server/src/api/journeys/journeys.service.ts
@@ -821,6 +821,7 @@ export class JourneysService {
         }),
         session: session,
         customer, //customer.id ?? customer._id.toString(),
+        stepDepth: 1,
       };
       jobsData.push(jobData);
     }

--- a/packages/server/src/api/journeys/processors/enrollment.processor.ts
+++ b/packages/server/src/api/journeys/processors/enrollment.processor.ts
@@ -38,7 +38,8 @@ export class EnrollmentProcessor extends WorkerHost {
     @Inject(CustomersService)
     private readonly customersService: CustomersService,
     @Inject(JourneysService)
-    private journeyService: JourneysService
+    private journeyService: JourneysService,
+    @Inject(QueueService) private queueService: QueueService,
   ) {
     super();
   }
@@ -120,7 +121,7 @@ export class EnrollmentProcessor extends WorkerHost {
     let err: any;
     let triggerStartTasks: {
       collectionName: string;
-      job: { name: string; data: any };
+      jobData: any
     };
     let collectionName: string;
     let count: number;
@@ -174,12 +175,11 @@ export class EnrollmentProcessor extends WorkerHost {
 
       await queryRunner.commitTransaction();
 
-      const jobPriority = this.stepsService.getJobPriorityForStepDepth(1);
-
       if (triggerStartTasks) {
         await this.queueService.addToQueue(
           this.startQueue,
-          triggerStartTasks.job.data
+          'start',
+          triggerStartTasks.jobData
         );
       }
     } catch (e) {

--- a/packages/server/src/api/journeys/processors/enrollment.processor.ts
+++ b/packages/server/src/api/journeys/processors/enrollment.processor.ts
@@ -18,6 +18,7 @@ import { Step } from '../../steps/entities/step.entity';
 import { StepsService } from '@/api/steps/steps.service';
 import { CustomersService } from '@/api/customers/customers.service';
 import { JourneysService } from '@/api/journeys/journeys.service';
+import { QueueService } from '@/common/services/queue.service';
 
 @Injectable()
 @Processor('{enrollment}', {
@@ -172,9 +173,12 @@ export class EnrollmentProcessor extends WorkerHost {
       });
 
       await queryRunner.commitTransaction();
+
+      const jobPriority = this.stepsService.getJobPriorityForStepDepth(1);
+
       if (triggerStartTasks) {
-        await this.startQueue.add(
-          triggerStartTasks.job.name,
+        await this.queueService.addToQueue(
+          this.startQueue,
           triggerStartTasks.job.data
         );
       }

--- a/packages/server/src/api/steps/processors/exit.step.processor.ts
+++ b/packages/server/src/api/steps/processors/exit.step.processor.ts
@@ -25,6 +25,7 @@ import { StepsService } from '../steps.service';
 import { Journey } from '@/api/journeys/entities/journey.entity';
 import { JourneyLocation } from '@/api/journeys/entities/journey-location.entity';
 import { CacheService } from '@/common/services/cache.service';
+import { QueueService } from '@/common/services/queue.service';
 
 @Injectable()
 @Processor('{exit.step}', {
@@ -50,20 +51,6 @@ export class ExitStepProcessor extends WorkerHost {
   constructor(
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private readonly logger: Logger,
-    @InjectQueue('{start.step}') private readonly startStepQueue: Queue,
-    @InjectQueue('{wait.until.step}')
-    private readonly waitUntilStepQueue: Queue,
-    @InjectQueue('{message.step}') private readonly messageStepQueue: Queue,
-    @InjectQueue('{jump.to.step}') private readonly jumpToStepQueue: Queue,
-    @InjectQueue('{time.delay.step}')
-    private readonly timeDelayStepQueue: Queue,
-    @InjectQueue('{time.window.step}')
-    private readonly timeWindowStepQueue: Queue,
-    @InjectQueue('{multisplit.step}')
-    private readonly multisplitStepQueue: Queue,
-    @InjectQueue('{experiment.step}')
-    private readonly experimentStepQueue: Queue,
-    @InjectQueue('{exit.step}') private readonly exitStepQueue: Queue,
     @InjectModel(Customer.name) public customerModel: Model<CustomerDocument>,
     @Inject(JourneyLocationsService)
     private journeyLocationsService: JourneyLocationsService
@@ -129,57 +116,6 @@ export class ExitStepProcessor extends WorkerHost {
       })
     );
   }
-
-  private processorMap: Record<
-    StepType,
-    (type: StepType, job: any) => Promise<void>
-  > = {
-    [StepType.START]: async (type, job) => {
-      await this.startStepQueue.add(type, job);
-    },
-    [StepType.EXPERIMENT]: async (type, job) => {
-      await this.experimentStepQueue.add(type, job);
-    },
-    [StepType.LOOP]: async (type, job) => {
-      await this.jumpToStepQueue.add(type, job);
-    },
-    [StepType.EXIT]: async (type, job) => {
-      await this.exitStepQueue.add(type, job);
-    },
-    [StepType.MULTISPLIT]: async (type, job) => {
-      await this.multisplitStepQueue.add(type, job);
-    },
-    [StepType.MESSAGE]: async (type: StepType, job: any) => {
-      await this.messageStepQueue.add(type, job);
-    },
-    [StepType.TIME_WINDOW]: async (type: StepType, job: any) => {
-      await this.timeWindowStepQueue.add(type, job);
-    },
-    [StepType.TIME_DELAY]: async (type: StepType, job: any) => {
-      await this.timeDelayStepQueue.add(type, job);
-    },
-    [StepType.WAIT_UNTIL_BRANCH]: async (type: StepType, job: any) => {
-      await this.waitUntilStepQueue.add(type, job);
-    },
-    [StepType.AB_TEST]: function (type: StepType, job: any): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-    [StepType.RANDOM_COHORT_BRANCH]: function (
-      type: StepType,
-      job: any
-    ): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-    [StepType.TRACKER]: function (type: StepType, job: any): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-    [StepType.ATTRIBUTE_BRANCH]: function (
-      type: StepType,
-      job: any
-    ): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-  };
 
   async process(
     job: Job<

--- a/packages/server/src/api/steps/processors/exit.step.processor.ts
+++ b/packages/server/src/api/steps/processors/exit.step.processor.ts
@@ -25,7 +25,6 @@ import { StepsService } from '../steps.service';
 import { Journey } from '@/api/journeys/entities/journey.entity';
 import { JourneyLocation } from '@/api/journeys/entities/journey-location.entity';
 import { CacheService } from '@/common/services/cache.service';
-import { QueueService } from '@/common/services/queue.service';
 
 @Injectable()
 @Processor('{exit.step}', {

--- a/packages/server/src/api/steps/processors/exit.step.processor.ts
+++ b/packages/server/src/api/steps/processors/exit.step.processor.ts
@@ -127,6 +127,7 @@ export class ExitStepProcessor extends WorkerHost {
         session: string;
         event?: string;
         branch?: number;
+        stepDepth: number;
       },
       any,
       string

--- a/packages/server/src/api/steps/processors/experiment.step.processor.ts
+++ b/packages/server/src/api/steps/processors/experiment.step.processor.ts
@@ -25,6 +25,7 @@ import { StepsService } from '../steps.service';
 import { Journey } from '@/api/journeys/entities/journey.entity';
 import { JourneyLocation } from '@/api/journeys/entities/journey-location.entity';
 import { CacheService } from '@/common/services/cache.service';
+import { QueueService } from '@/common/services/queue.service';
 
 @Injectable()
 @Processor('{experiment.step}', {
@@ -50,25 +51,12 @@ export class ExperimentStepProcessor extends WorkerHost {
   constructor(
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private readonly logger: Logger,
-    @InjectQueue('{start.step}') private readonly startStepQueue: Queue,
-    @InjectQueue('{wait.until.step}')
-    private readonly waitUntilStepQueue: Queue,
-    @InjectQueue('{message.step}') private readonly messageStepQueue: Queue,
-    @InjectQueue('{jump.to.step}') private readonly jumpToStepQueue: Queue,
-    @InjectQueue('{time.delay.step}')
-    private readonly timeDelayStepQueue: Queue,
-    @InjectQueue('{time.window.step}')
-    private readonly timeWindowStepQueue: Queue,
-    @InjectQueue('{multisplit.step}')
-    private readonly multisplitStepQueue: Queue,
-    @InjectQueue('{experiment.step}')
-    private readonly experimentStepQueue: Queue,
-    @InjectQueue('{exit.step}') private readonly exitStepQueue: Queue,
     @InjectModel(Customer.name) public customerModel: Model<CustomerDocument>,
     @Inject(JourneyLocationsService)
     private journeyLocationsService: JourneyLocationsService,
     @Inject(StepsService) private stepsService: StepsService,
-    @Inject(CacheService) private cacheService: CacheService
+    @Inject(CacheService) private cacheService: CacheService,
+    @Inject(QueueService) private queueService: QueueService,
   ) {
     super();
   }
@@ -132,57 +120,6 @@ export class ExperimentStepProcessor extends WorkerHost {
     );
   }
 
-  private processorMap: Record<
-    StepType,
-    (type: StepType, job: any) => Promise<void>
-  > = {
-    [StepType.START]: async (type, job) => {
-      await this.startStepQueue.add(type, job);
-    },
-    [StepType.EXPERIMENT]: async (type, job) => {
-      await this.experimentStepQueue.add(type, job);
-    },
-    [StepType.LOOP]: async (type, job) => {
-      await this.jumpToStepQueue.add(type, job);
-    },
-    [StepType.EXIT]: async (type, job) => {
-      await this.exitStepQueue.add(type, job);
-    },
-    [StepType.MULTISPLIT]: async (type, job) => {
-      await this.multisplitStepQueue.add(type, job);
-    },
-    [StepType.MESSAGE]: async (type: StepType, job: any) => {
-      await this.messageStepQueue.add(type, job);
-    },
-    [StepType.TIME_WINDOW]: async (type: StepType, job: any) => {
-      await this.timeWindowStepQueue.add(type, job);
-    },
-    [StepType.TIME_DELAY]: async (type: StepType, job: any) => {
-      await this.timeDelayStepQueue.add(type, job);
-    },
-    [StepType.WAIT_UNTIL_BRANCH]: async (type: StepType, job: any) => {
-      await this.waitUntilStepQueue.add(type, job);
-    },
-    [StepType.AB_TEST]: function (type: StepType, job: any): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-    [StepType.RANDOM_COHORT_BRANCH]: function (
-      type: StepType,
-      job: any
-    ): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-    [StepType.TRACKER]: function (type: StepType, job: any): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-    [StepType.ATTRIBUTE_BRANCH]: function (
-      type: StepType,
-      job: any
-    ): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-  };
-
   async process(
     job: Job<
       {
@@ -194,6 +131,7 @@ export class ExperimentStepProcessor extends WorkerHost {
         session: string;
         event?: string;
         branch?: number;
+        stepDepth: number;
       },
       any,
       string
@@ -225,6 +163,8 @@ export class ExperimentStepProcessor extends WorkerHost {
         );
 
         if (nextStep) {
+          const nextStepDepth: number = this.queueService.getNextStepDepthFromJob(job);
+
           if (
             nextStep.type !== StepType.TIME_DELAY &&
             nextStep.type !== StepType.TIME_WINDOW &&
@@ -238,6 +178,7 @@ export class ExperimentStepProcessor extends WorkerHost {
               location: job.data.location,
               customer: job.data.customer,
               event: job.data.event,
+              stepDepth: nextStepDepth
             };
           } else {
             // Destination is time based,
@@ -256,7 +197,7 @@ export class ExperimentStepProcessor extends WorkerHost {
           );
         }
         if (nextStep && nextJob)
-          await this.processorMap[nextStep.type](nextStep.type, nextJob);
+          await this.queueService.add(nextStep.type, nextJob);
       }
     );
   }

--- a/packages/server/src/api/steps/processors/jump.to.step.processor.ts
+++ b/packages/server/src/api/steps/processors/jump.to.step.processor.ts
@@ -25,6 +25,7 @@ import { StepsService } from '../steps.service';
 import { Journey } from '@/api/journeys/entities/journey.entity';
 import { JourneyLocation } from '@/api/journeys/entities/journey-location.entity';
 import { CacheService } from '@/common/services/cache.service';
+import { QueueService } from '@/common/services/queue.service';
 
 @Injectable()
 @Processor('{jump.to.step}', {
@@ -50,25 +51,12 @@ export class JumpToStepProcessor extends WorkerHost {
   constructor(
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private readonly logger: Logger,
-    @InjectQueue('{start.step}') private readonly startStepQueue: Queue,
-    @InjectQueue('{wait.until.step}')
-    private readonly waitUntilStepQueue: Queue,
-    @InjectQueue('{message.step}') private readonly messageStepQueue: Queue,
-    @InjectQueue('{jump.to.step}') private readonly jumpToStepQueue: Queue,
-    @InjectQueue('{time.delay.step}')
-    private readonly timeDelayStepQueue: Queue,
-    @InjectQueue('{time.window.step}')
-    private readonly timeWindowStepQueue: Queue,
-    @InjectQueue('{multisplit.step}')
-    private readonly multisplitStepQueue: Queue,
-    @InjectQueue('{experiment.step}')
-    private readonly experimentStepQueue: Queue,
-    @InjectQueue('{exit.step}') private readonly exitStepQueue: Queue,
     @InjectModel(Customer.name) public customerModel: Model<CustomerDocument>,
     @Inject(JourneyLocationsService)
     private journeyLocationsService: JourneyLocationsService,
     @Inject(StepsService) private stepsService: StepsService,
-    @Inject(CacheService) private cacheService: CacheService
+    @Inject(CacheService) private cacheService: CacheService,
+    @Inject(QueueService) private queueService: QueueService,
   ) {
     super();
   }
@@ -132,57 +120,6 @@ export class JumpToStepProcessor extends WorkerHost {
     );
   }
 
-  private processorMap: Record<
-    StepType,
-    (type: StepType, job: any) => Promise<void>
-  > = {
-    [StepType.START]: async (type, job) => {
-      await this.startStepQueue.add(type, job);
-    },
-    [StepType.EXPERIMENT]: async (type, job) => {
-      await this.experimentStepQueue.add(type, job);
-    },
-    [StepType.LOOP]: async (type, job) => {
-      await this.jumpToStepQueue.add(type, job);
-    },
-    [StepType.EXIT]: async (type, job) => {
-      await this.exitStepQueue.add(type, job);
-    },
-    [StepType.MULTISPLIT]: async (type, job) => {
-      await this.multisplitStepQueue.add(type, job);
-    },
-    [StepType.MESSAGE]: async (type: StepType, job: any) => {
-      await this.messageStepQueue.add(type, job);
-    },
-    [StepType.TIME_WINDOW]: async (type: StepType, job: any) => {
-      await this.timeWindowStepQueue.add(type, job);
-    },
-    [StepType.TIME_DELAY]: async (type: StepType, job: any) => {
-      await this.timeDelayStepQueue.add(type, job);
-    },
-    [StepType.WAIT_UNTIL_BRANCH]: async (type: StepType, job: any) => {
-      await this.waitUntilStepQueue.add(type, job);
-    },
-    [StepType.AB_TEST]: function (type: StepType, job: any): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-    [StepType.RANDOM_COHORT_BRANCH]: function (
-      type: StepType,
-      job: any
-    ): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-    [StepType.TRACKER]: function (type: StepType, job: any): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-    [StepType.ATTRIBUTE_BRANCH]: function (
-      type: StepType,
-      job: any
-    ): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-  };
-
   async process(
     job: Job<
       {
@@ -194,6 +131,7 @@ export class JumpToStepProcessor extends WorkerHost {
         session: string;
         event?: string;
         branch?: number;
+        stepDepth: number;
       },
       any,
       string
@@ -215,6 +153,8 @@ export class JumpToStepProcessor extends WorkerHost {
         );
 
         if (nextStep) {
+          const nextStepDepth: number = this.queueService.getNextStepDepthFromJob(job);
+          
           if (
             nextStep.type !== StepType.TIME_DELAY &&
             nextStep.type !== StepType.TIME_WINDOW &&
@@ -228,6 +168,7 @@ export class JumpToStepProcessor extends WorkerHost {
               customer: job.data.customer,
               location: job.data.location,
               event: job.data.event,
+              stepDepth: nextStepDepth
             };
           } else {
             // Destination is time based,
@@ -246,7 +187,7 @@ export class JumpToStepProcessor extends WorkerHost {
           );
         }
         if (nextStep && nextJob)
-          await this.processorMap[nextStep.type](nextStep.type, nextJob);
+          await this.queueService.add(nextStep.type, nextJob);
       }
     );
   }

--- a/packages/server/src/api/steps/processors/multisplit.step.processor.ts
+++ b/packages/server/src/api/steps/processors/multisplit.step.processor.ts
@@ -26,6 +26,7 @@ import { Journey } from '@/api/journeys/entities/journey.entity';
 import { JourneyLocation } from '@/api/journeys/entities/journey-location.entity';
 import { CacheService } from '@/common/services/cache.service';
 import { CustomersService } from '@/api/customers/customers.service';
+import { QueueService } from '@/common/services/queue.service';
 
 @Injectable()
 @Processor('{multisplit.step}', {
@@ -70,7 +71,8 @@ export class MultisplitStepProcessor extends WorkerHost {
     private journeyLocationsService: JourneyLocationsService,
     @Inject(StepsService) private stepsService: StepsService,
     @Inject(CacheService) private cacheService: CacheService,
-    @Inject(CustomersService) private customersService: CustomersService
+    @Inject(CustomersService) private customersService: CustomersService,
+    @Inject(QueueService) private queueService: QueueService,
   ) {
     super();
   }
@@ -134,57 +136,6 @@ export class MultisplitStepProcessor extends WorkerHost {
     );
   }
 
-  private processorMap: Record<
-    StepType,
-    (type: StepType, job: any) => Promise<void>
-  > = {
-    [StepType.START]: async (type, job) => {
-      await this.startStepQueue.add(type, job);
-    },
-    [StepType.EXPERIMENT]: async (type, job) => {
-      await this.experimentStepQueue.add(type, job);
-    },
-    [StepType.LOOP]: async (type, job) => {
-      await this.jumpToStepQueue.add(type, job);
-    },
-    [StepType.EXIT]: async (type, job) => {
-      await this.exitStepQueue.add(type, job);
-    },
-    [StepType.MULTISPLIT]: async (type, job) => {
-      await this.multisplitStepQueue.add(type, job);
-    },
-    [StepType.MESSAGE]: async (type: StepType, job: any) => {
-      await this.messageStepQueue.add(type, job);
-    },
-    [StepType.TIME_WINDOW]: async (type: StepType, job: any) => {
-      await this.timeWindowStepQueue.add(type, job);
-    },
-    [StepType.TIME_DELAY]: async (type: StepType, job: any) => {
-      await this.timeDelayStepQueue.add(type, job);
-    },
-    [StepType.WAIT_UNTIL_BRANCH]: async (type: StepType, job: any) => {
-      await this.waitUntilStepQueue.add(type, job);
-    },
-    [StepType.AB_TEST]: function (type: StepType, job: any): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-    [StepType.RANDOM_COHORT_BRANCH]: function (
-      type: StepType,
-      job: any
-    ): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-    [StepType.TRACKER]: function (type: StepType, job: any): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-    [StepType.ATTRIBUTE_BRANCH]: function (
-      type: StepType,
-      job: any
-    ): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-  };
-
   async process(
     job: Job<
       {
@@ -196,6 +147,7 @@ export class MultisplitStepProcessor extends WorkerHost {
         session: string;
         event?: string;
         branch?: number;
+        stepDepth: number;
       },
       any,
       string
@@ -239,6 +191,8 @@ export class MultisplitStepProcessor extends WorkerHost {
         );
 
         if (nextStep) {
+          const nextStepDepth: number = this.queueService.getNextStepDepthFromJob(job);
+
           if (
             nextStep.type !== StepType.TIME_DELAY &&
             nextStep.type !== StepType.TIME_WINDOW &&
@@ -252,6 +206,7 @@ export class MultisplitStepProcessor extends WorkerHost {
               customer: job.data.customer,
               location: job.data.location,
               event: job.data.event,
+              stepDepth: nextStepDepth
             };
           } else {
             // Destination is time based,
@@ -271,7 +226,7 @@ export class MultisplitStepProcessor extends WorkerHost {
         }
 
         if (nextStep && nextJob)
-          await this.processorMap[nextStep.type](nextStep.type, nextJob);
+          await this.queueService.add(nextStep.type, nextJob);
       }
     );
   }

--- a/packages/server/src/api/steps/processors/start.step.processor.ts
+++ b/packages/server/src/api/steps/processors/start.step.processor.ts
@@ -131,6 +131,7 @@ export class StartStepProcessor extends WorkerHost {
         session: string;
         event?: string;
         branch?: number;
+        stepDepth: number;
       },
       any,
       string
@@ -140,9 +141,6 @@ export class StartStepProcessor extends WorkerHost {
       { name: 'StartStepProcessor.process' },
       async () => {
         let nextJob;
-
-        const nextStepDepth: number = 2;
-        const nextStepJobPriority = this.stepsService.getStepJobPriority(nextStepDepth);
 
         let nextStep: Step = await this.cacheService.getIgnoreError(
           Step,
@@ -155,6 +153,8 @@ export class StartStepProcessor extends WorkerHost {
         );
 
         if (nextStep) {
+          const nextStepDepth: number = this.queueService.getNextStepDepthFromJob(job);
+          
           if (
             nextStep.type !== StepType.TIME_DELAY &&
             nextStep.type !== StepType.TIME_WINDOW &&
@@ -187,7 +187,7 @@ export class StartStepProcessor extends WorkerHost {
           );
         }
         if (nextStep && nextJob)
-          await this.queueService.add(nextStep.type, nextJob, nextStepJobPriority);
+          await this.queueService.add(nextStep.type, nextJob);
       }
     );
   }

--- a/packages/server/src/api/steps/processors/start.step.processor.ts
+++ b/packages/server/src/api/steps/processors/start.step.processor.ts
@@ -25,6 +25,7 @@ import { StepsService } from '../steps.service';
 import { Journey } from '@/api/journeys/entities/journey.entity';
 import { JourneyLocation } from '@/api/journeys/entities/journey-location.entity';
 import { CacheService } from '@/common/services/cache.service';
+import { QueueService } from '@/common/services/queue.service';
 
 @Injectable()
 @Processor('{start.step}', {
@@ -50,25 +51,12 @@ export class StartStepProcessor extends WorkerHost {
   constructor(
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private readonly logger: Logger,
-    @InjectQueue('{start.step}') private readonly startStepQueue: Queue,
-    @InjectQueue('{wait.until.step}')
-    private readonly waitUntilStepQueue: Queue,
-    @InjectQueue('{message.step}') private readonly messageStepQueue: Queue,
-    @InjectQueue('{jump.to.step}') private readonly jumpToStepQueue: Queue,
-    @InjectQueue('{time.delay.step}')
-    private readonly timeDelayStepQueue: Queue,
-    @InjectQueue('{time.window.step}')
-    private readonly timeWindowStepQueue: Queue,
-    @InjectQueue('{multisplit.step}')
-    private readonly multisplitStepQueue: Queue,
-    @InjectQueue('{experiment.step}')
-    private readonly experimentStepQueue: Queue,
-    @InjectQueue('{exit.step}') private readonly exitStepQueue: Queue,
     @InjectModel(Customer.name) public customerModel: Model<CustomerDocument>,
     @Inject(JourneyLocationsService)
     private journeyLocationsService: JourneyLocationsService,
     @Inject(StepsService) private stepsService: StepsService,
-    @Inject(CacheService) private cacheService: CacheService
+    @Inject(CacheService) private cacheService: CacheService,
+    @Inject(QueueService) private queueService: QueueService,
   ) {
     super();
   }
@@ -132,57 +120,6 @@ export class StartStepProcessor extends WorkerHost {
     );
   }
 
-  private processorMap: Record<
-    StepType,
-    (type: StepType, job: any) => Promise<void>
-  > = {
-    [StepType.START]: async (type, job) => {
-      await this.startStepQueue.add(type, job);
-    },
-    [StepType.EXPERIMENT]: async (type, job) => {
-      await this.experimentStepQueue.add(type, job);
-    },
-    [StepType.LOOP]: async (type, job) => {
-      await this.jumpToStepQueue.add(type, job);
-    },
-    [StepType.EXIT]: async (type, job) => {
-      await this.exitStepQueue.add(type, job);
-    },
-    [StepType.MULTISPLIT]: async (type, job) => {
-      await this.multisplitStepQueue.add(type, job);
-    },
-    [StepType.MESSAGE]: async (type: StepType, job: any) => {
-      await this.messageStepQueue.add(type, job);
-    },
-    [StepType.TIME_WINDOW]: async (type: StepType, job: any) => {
-      await this.timeWindowStepQueue.add(type, job);
-    },
-    [StepType.TIME_DELAY]: async (type: StepType, job: any) => {
-      await this.timeDelayStepQueue.add(type, job);
-    },
-    [StepType.WAIT_UNTIL_BRANCH]: async (type: StepType, job: any) => {
-      await this.waitUntilStepQueue.add(type, job);
-    },
-    [StepType.AB_TEST]: function (type: StepType, job: any): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-    [StepType.RANDOM_COHORT_BRANCH]: function (
-      type: StepType,
-      job: any
-    ): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-    [StepType.TRACKER]: function (type: StepType, job: any): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-    [StepType.ATTRIBUTE_BRANCH]: function (
-      type: StepType,
-      job: any
-    ): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-  };
-
   async process(
     job: Job<
       {
@@ -203,6 +140,9 @@ export class StartStepProcessor extends WorkerHost {
       { name: 'StartStepProcessor.process' },
       async () => {
         let nextJob;
+
+        const nextStepDepth: number = 2;
+        const nextStepJobPriority = this.stepsService.getStepJobPriority(nextStepDepth);
 
         let nextStep: Step = await this.cacheService.getIgnoreError(
           Step,
@@ -228,6 +168,7 @@ export class StartStepProcessor extends WorkerHost {
               customer: job.data.customer,
               location: job.data.location,
               event: job.data.event,
+              stepDepth: nextStepDepth
             };
           } else {
             // Destination is time based,
@@ -246,7 +187,7 @@ export class StartStepProcessor extends WorkerHost {
           );
         }
         if (nextStep && nextJob)
-          await this.processorMap[nextStep.type](nextStep.type, nextJob);
+          await this.queueService.add(nextStep.type, nextJob, nextStepJobPriority);
       }
     );
   }

--- a/packages/server/src/api/steps/processors/time.delay.step.processor.ts
+++ b/packages/server/src/api/steps/processors/time.delay.step.processor.ts
@@ -26,6 +26,7 @@ import { Journey } from '@/api/journeys/entities/journey.entity';
 import { JourneyLocation } from '@/api/journeys/entities/journey-location.entity';
 import { CacheService } from '@/common/services/cache.service';
 import { Temporal } from '@js-temporal/polyfill';
+import { QueueService } from '@/common/services/queue.service';
 
 @Injectable()
 @Processor('{time.delay.step}', {
@@ -51,25 +52,12 @@ export class TimeDelayStepProcessor extends WorkerHost {
   constructor(
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private readonly logger: Logger,
-    @InjectQueue('{start.step}') private readonly startStepQueue: Queue,
-    @InjectQueue('{wait.until.step}')
-    private readonly waitUntilStepQueue: Queue,
-    @InjectQueue('{message.step}') private readonly messageStepQueue: Queue,
-    @InjectQueue('{jump.to.step}') private readonly jumpToStepQueue: Queue,
-    @InjectQueue('{time.delay.step}')
-    private readonly timeDelayStepQueue: Queue,
-    @InjectQueue('{time.window.step}')
-    private readonly timeWindowStepQueue: Queue,
-    @InjectQueue('{multisplit.step}')
-    private readonly multisplitStepQueue: Queue,
-    @InjectQueue('{experiment.step}')
-    private readonly experimentStepQueue: Queue,
-    @InjectQueue('{exit.step}') private readonly exitStepQueue: Queue,
     @InjectModel(Customer.name) public customerModel: Model<CustomerDocument>,
     @Inject(JourneyLocationsService)
     private journeyLocationsService: JourneyLocationsService,
     @Inject(StepsService) private stepsService: StepsService,
-    @Inject(CacheService) private cacheService: CacheService
+    @Inject(CacheService) private cacheService: CacheService,
+    @Inject(QueueService) private queueService: QueueService,
   ) {
     super();
   }
@@ -133,57 +121,6 @@ export class TimeDelayStepProcessor extends WorkerHost {
     );
   }
 
-  private processorMap: Record<
-    StepType,
-    (type: StepType, job: any) => Promise<void>
-  > = {
-    [StepType.START]: async (type, job) => {
-      await this.startStepQueue.add(type, job);
-    },
-    [StepType.EXPERIMENT]: async (type, job) => {
-      await this.experimentStepQueue.add(type, job);
-    },
-    [StepType.LOOP]: async (type, job) => {
-      await this.jumpToStepQueue.add(type, job);
-    },
-    [StepType.EXIT]: async (type, job) => {
-      await this.exitStepQueue.add(type, job);
-    },
-    [StepType.MULTISPLIT]: async (type, job) => {
-      await this.multisplitStepQueue.add(type, job);
-    },
-    [StepType.MESSAGE]: async (type: StepType, job: any) => {
-      await this.messageStepQueue.add(type, job);
-    },
-    [StepType.TIME_WINDOW]: async (type: StepType, job: any) => {
-      await this.timeWindowStepQueue.add(type, job);
-    },
-    [StepType.TIME_DELAY]: async (type: StepType, job: any) => {
-      await this.timeDelayStepQueue.add(type, job);
-    },
-    [StepType.WAIT_UNTIL_BRANCH]: async (type: StepType, job: any) => {
-      await this.waitUntilStepQueue.add(type, job);
-    },
-    [StepType.AB_TEST]: function (type: StepType, job: any): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-    [StepType.RANDOM_COHORT_BRANCH]: function (
-      type: StepType,
-      job: any
-    ): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-    [StepType.TRACKER]: function (type: StepType, job: any): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-    [StepType.ATTRIBUTE_BRANCH]: function (
-      type: StepType,
-      job: any
-    ): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-  };
-
   async process(
     job: Job<
       {
@@ -195,6 +132,7 @@ export class TimeDelayStepProcessor extends WorkerHost {
         session: string;
         event?: string;
         branch?: number;
+        stepDepth: number;
       },
       any,
       string
@@ -221,6 +159,8 @@ export class TimeDelayStepProcessor extends WorkerHost {
           );
 
           if (nextStep) {
+            const nextStepDepth: number = this.queueService.getNextStepDepthFromJob(job);
+
             if (
               nextStep.type !== StepType.TIME_DELAY &&
               nextStep.type !== StepType.TIME_WINDOW &&
@@ -234,6 +174,7 @@ export class TimeDelayStepProcessor extends WorkerHost {
                 customer: job.data.customer,
                 location: job.data.location,
                 event: job.data.event,
+                stepDepth: nextStepDepth
               };
             } else {
               // Destination is time based,
@@ -260,7 +201,7 @@ export class TimeDelayStepProcessor extends WorkerHost {
           );
         }
         if (nextStep && nextJob)
-          await this.processorMap[nextStep.type](nextStep.type, nextJob);
+          await this.queueService.add(nextStep.type, nextJob);
       }
     );
   }

--- a/packages/server/src/api/steps/processors/time.window.step.processor.ts
+++ b/packages/server/src/api/steps/processors/time.window.step.processor.ts
@@ -26,6 +26,7 @@ import { Journey } from '@/api/journeys/entities/journey.entity';
 import { JourneyLocation } from '@/api/journeys/entities/journey-location.entity';
 import { CacheService } from '@/common/services/cache.service';
 import { Temporal } from '@js-temporal/polyfill';
+import { QueueService } from '@/common/services/queue.service';
 
 @Injectable()
 @Processor('{time.window.step}', {
@@ -51,25 +52,12 @@ export class TimeWindowStepProcessor extends WorkerHost {
   constructor(
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private readonly logger: Logger,
-    @InjectQueue('{start.step}') private readonly startStepQueue: Queue,
-    @InjectQueue('{wait.until.step}')
-    private readonly waitUntilStepQueue: Queue,
-    @InjectQueue('{message.step}') private readonly messageStepQueue: Queue,
-    @InjectQueue('{jump.to.step}') private readonly jumpToStepQueue: Queue,
-    @InjectQueue('{time.delay.step}')
-    private readonly timeDelayStepQueue: Queue,
-    @InjectQueue('{time.window.step}')
-    private readonly timeWindowStepQueue: Queue,
-    @InjectQueue('{multisplit.step}')
-    private readonly multisplitStepQueue: Queue,
-    @InjectQueue('{experiment.step}')
-    private readonly experimentStepQueue: Queue,
-    @InjectQueue('{exit.step}') private readonly exitStepQueue: Queue,
     @InjectModel(Customer.name) public customerModel: Model<CustomerDocument>,
     @Inject(JourneyLocationsService)
     private journeyLocationsService: JourneyLocationsService,
     @Inject(StepsService) private stepsService: StepsService,
-    @Inject(CacheService) private cacheService: CacheService
+    @Inject(CacheService) private cacheService: CacheService,
+    @Inject(QueueService) private queueService: QueueService,
   ) {
     super();
   }
@@ -133,57 +121,6 @@ export class TimeWindowStepProcessor extends WorkerHost {
     );
   }
 
-  private processorMap: Record<
-    StepType,
-    (type: StepType, job: any) => Promise<void>
-  > = {
-    [StepType.START]: async (type, job) => {
-      await this.startStepQueue.add(type, job);
-    },
-    [StepType.EXPERIMENT]: async (type, job) => {
-      await this.experimentStepQueue.add(type, job);
-    },
-    [StepType.LOOP]: async (type, job) => {
-      await this.jumpToStepQueue.add(type, job);
-    },
-    [StepType.EXIT]: async (type, job) => {
-      await this.exitStepQueue.add(type, job);
-    },
-    [StepType.MULTISPLIT]: async (type, job) => {
-      await this.multisplitStepQueue.add(type, job);
-    },
-    [StepType.MESSAGE]: async (type: StepType, job: any) => {
-      await this.messageStepQueue.add(type, job);
-    },
-    [StepType.TIME_WINDOW]: async (type: StepType, job: any) => {
-      await this.timeWindowStepQueue.add(type, job);
-    },
-    [StepType.TIME_DELAY]: async (type: StepType, job: any) => {
-      await this.timeDelayStepQueue.add(type, job);
-    },
-    [StepType.WAIT_UNTIL_BRANCH]: async (type: StepType, job: any) => {
-      await this.waitUntilStepQueue.add(type, job);
-    },
-    [StepType.AB_TEST]: function (type: StepType, job: any): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-    [StepType.RANDOM_COHORT_BRANCH]: function (
-      type: StepType,
-      job: any
-    ): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-    [StepType.TRACKER]: function (type: StepType, job: any): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-    [StepType.ATTRIBUTE_BRANCH]: function (
-      type: StepType,
-      job: any
-    ): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-  };
-
   async process(
     job: Job<
       {
@@ -195,6 +132,7 @@ export class TimeWindowStepProcessor extends WorkerHost {
         session: string;
         event?: string;
         branch?: number;
+        stepDepth: number;
       },
       any,
       string
@@ -264,6 +202,8 @@ export class TimeWindowStepProcessor extends WorkerHost {
           );
 
           if (nextStep) {
+            const nextStepDepth: number = this.queueService.getNextStepDepthFromJob(job);
+
             if (
               nextStep.type !== StepType.TIME_DELAY &&
               nextStep.type !== StepType.TIME_WINDOW &&
@@ -277,6 +217,7 @@ export class TimeWindowStepProcessor extends WorkerHost {
                 customer: job.data.customer,
                 location: job.data.location,
                 event: job.data.event,
+                stepDepth: nextStepDepth
               };
             } else {
               // Destination is time based,
@@ -303,7 +244,7 @@ export class TimeWindowStepProcessor extends WorkerHost {
           );
         }
         if (nextStep && nextJob)
-          await this.processorMap[nextStep.type](nextStep.type, nextJob);
+          await this.queueService.add(nextStep.type, nextJob);
       }
     );
   }

--- a/packages/server/src/api/steps/processors/wait.until.step.processor.ts
+++ b/packages/server/src/api/steps/processors/wait.until.step.processor.ts
@@ -21,6 +21,7 @@ import { Journey } from '@/api/journeys/entities/journey.entity';
 import { JourneyLocation } from '@/api/journeys/entities/journey-location.entity';
 import { CacheService } from '@/common/services/cache.service';
 import { Temporal } from '@js-temporal/polyfill';
+import { QueueService } from '@/common/services/queue.service';
 
 @Injectable()
 @Processor('{wait.until.step}', {
@@ -46,24 +47,11 @@ export class WaitUntilStepProcessor extends WorkerHost {
   constructor(
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private readonly logger: Logger,
-    @InjectQueue('{start.step}') private readonly startStepQueue: Queue,
-    @InjectQueue('{wait.until.step}')
-    private readonly waitUntilStepQueue: Queue,
-    @InjectQueue('{message.step}') private readonly messageStepQueue: Queue,
-    @InjectQueue('{jump.to.step}') private readonly jumpToStepQueue: Queue,
-    @InjectQueue('{time.delay.step}')
-    private readonly timeDelayStepQueue: Queue,
-    @InjectQueue('{time.window.step}')
-    private readonly timeWindowStepQueue: Queue,
-    @InjectQueue('{multisplit.step}')
-    private readonly multisplitStepQueue: Queue,
-    @InjectQueue('{experiment.step}')
-    private readonly experimentStepQueue: Queue,
-    @InjectQueue('{exit.step}') private readonly exitStepQueue: Queue,
     @Inject(JourneyLocationsService)
     private journeyLocationsService: JourneyLocationsService,
     @Inject(StepsService) private stepsService: StepsService,
-    @Inject(CacheService) private cacheService: CacheService
+    @Inject(CacheService) private cacheService: CacheService,
+    @Inject(QueueService) private queueService: QueueService,
   ) {
     super();
   }
@@ -127,57 +115,6 @@ export class WaitUntilStepProcessor extends WorkerHost {
     );
   }
 
-  private processorMap: Record<
-    StepType,
-    (type: StepType, job: any) => Promise<void>
-  > = {
-    [StepType.START]: async (type, job) => {
-      await this.startStepQueue.add(type, job);
-    },
-    [StepType.EXPERIMENT]: async (type, job) => {
-      await this.experimentStepQueue.add(type, job);
-    },
-    [StepType.LOOP]: async (type, job) => {
-      await this.jumpToStepQueue.add(type, job);
-    },
-    [StepType.EXIT]: async (type, job) => {
-      await this.exitStepQueue.add(type, job);
-    },
-    [StepType.MULTISPLIT]: async (type, job) => {
-      await this.multisplitStepQueue.add(type, job);
-    },
-    [StepType.MESSAGE]: async (type: StepType, job: any) => {
-      await this.messageStepQueue.add(type, job);
-    },
-    [StepType.TIME_WINDOW]: async (type: StepType, job: any) => {
-      await this.timeWindowStepQueue.add(type, job);
-    },
-    [StepType.TIME_DELAY]: async (type: StepType, job: any) => {
-      await this.timeDelayStepQueue.add(type, job);
-    },
-    [StepType.WAIT_UNTIL_BRANCH]: async (type: StepType, job: any) => {
-      await this.waitUntilStepQueue.add(type, job);
-    },
-    [StepType.AB_TEST]: function (type: StepType, job: any): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-    [StepType.RANDOM_COHORT_BRANCH]: function (
-      type: StepType,
-      job: any
-    ): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-    [StepType.TRACKER]: function (type: StepType, job: any): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-    [StepType.ATTRIBUTE_BRANCH]: function (
-      type: StepType,
-      job: any
-    ): Promise<void> {
-      throw new Error('Function not implemented.');
-    },
-  };
-
   async process(
     job: Job<
       {
@@ -189,6 +126,7 @@ export class WaitUntilStepProcessor extends WorkerHost {
         session: string;
         event?: string;
         branch?: number;
+        stepDepth: number;
       },
       any,
       string
@@ -275,6 +213,8 @@ export class WaitUntilStepProcessor extends WorkerHost {
             );
 
             if (nextStep) {
+              const nextStepDepth: number = this.queueService.getNextStepDepthFromJob(job);
+
               if (
                 nextStep.type !== StepType.TIME_DELAY &&
                 nextStep.type !== StepType.TIME_WINDOW &&
@@ -288,6 +228,7 @@ export class WaitUntilStepProcessor extends WorkerHost {
                   customer: job.data.customer,
                   location: job.data.location,
                   event: job.data.event,
+                  stepDepth: nextStepDepth
                 };
               } else {
                 // Destination is time based,
@@ -369,7 +310,7 @@ export class WaitUntilStepProcessor extends WorkerHost {
           );
         }
         if (nextStep && nextJob)
-          await this.processorMap[nextStep.type](nextStep.type, nextJob);
+          await this.queueService.add(nextStep.type, nextJob);
       }
     );
   }

--- a/packages/server/src/api/steps/steps.module.ts
+++ b/packages/server/src/api/steps/steps.module.ts
@@ -45,6 +45,7 @@ import { StartStepProcessor } from './processors/start.step.processor';
 import { TimeDelayStepProcessor } from './processors/time.delay.step.processor';
 import { TimeWindowStepProcessor } from './processors/time.window.step.processor';
 import { WaitUntilStepProcessor } from './processors/wait.until.step.processor';
+import { QueueService } from '@/common/services/queue.service';
 
 function getProvidersList() {
   let providerList: Array<any> = [
@@ -53,6 +54,7 @@ function getProvidersList() {
     RedlockService,
     JourneyLocationsService,
     CacheService,
+    QueueService
   ];
 
   if (process.env.LAUDSPEAKER_PROCESS_TYPE == 'QUEUE') {

--- a/packages/server/src/api/steps/steps.service.ts
+++ b/packages/server/src/api/steps/steps.service.ts
@@ -157,7 +157,7 @@ export class StepsService {
     client?: any,
     session?: string,
     collectionName?: string
-  ): Promise<{ collectionName: string; job: { name: string; data: any } }> {
+  ): Promise<{ collectionName: string; jobData: any }> {
     return Sentry.startSpan({ name: 'StepsService.triggerStart' }, async () => {
       const workspace = account?.teams?.[0]?.organization?.workspaces?.[0];
 
@@ -207,18 +207,15 @@ export class StepsService {
 
       return {
         collectionName,
-        job: {
-          name: 'start',
-          data: {
-            owner: account,
-            step: startStep[0],
-            journey,
-            session: session,
-            query,
-            skip: 0,
-            limit: audienceSize,
-            collectionName,
-          },
+        jobData: {
+          owner: account,
+          step: startStep[0],
+          journey,
+          session: session,
+          query,
+          skip: 0,
+          limit: audienceSize,
+          collectionName,
         },
       };
     });

--- a/packages/server/src/app.cron.service.ts
+++ b/packages/server/src/app.cron.service.ts
@@ -122,10 +122,6 @@ export class CronService {
     @Inject(StepsService) private stepsService: StepsService,
     @Inject(JourneyLocationsService)
     private journeyLocationsService: JourneyLocationsService,
-    @InjectQueue('{wait.until.step}')
-    private readonly waitUntilStepQueue: Queue,
-    @InjectQueue('{time.delay.step}') private readonly timeDelayStep: Queue,
-    @InjectQueue('{time.window.step}') private readonly timeWindowStep: Queue,
     @InjectQueue('{transition}') private readonly transitionQueue: Queue,
     @InjectQueue('{start}') private readonly startQueue: Queue,
     @Inject(RedlockService)
@@ -529,21 +525,6 @@ export class CronService {
         await this.queueService.addBulk(StepType.WAIT_UNTIL_BRANCH, waitUntilJobsData);
         await this.queueService.addBulk(StepType.TIME_DELAY, timeDelayJobsData);
         await this.queueService.addBulk(StepType.TIME_WINDOW, timeWindowJobsData);
-        // await this.waitUntilStepQueue.addBulk(
-        //   timeBasedJobs.filter((job) => {
-        //     return job.name === String(StepType.WAIT_UNTIL_BRANCH);
-        //   })
-        // );
-        // await this.timeDelayStep.addBulk(
-        //   timeBasedJobs.filter((job) => {
-        //     return job.name === String(StepType.TIME_DELAY);
-        //   })
-        // );
-        // await this.timeWindowStep.addBulk(
-        //   timeBasedJobs.filter((job) => {
-        //     return job.name === String(StepType.TIME_WINDOW);
-        //   })
-        // );
       }
 
       // Handle expiry of recovery emails
@@ -1490,10 +1471,10 @@ export class CronService {
           //   await this.connection.dropCollection(collection);
           // }
           if (triggerStartTasks?.jobData)
-
-            await this.startQueue.add(
-              triggerStartTasks.job.name,
-              triggerStartTasks.job.data
+            await this.queueService.addToQueue(
+              this.startQueue,
+              'start',
+              triggerStartTasks.jobData
             );
         } catch (e) {
           this.error(e, this.handleEntryTiming.name, session);

--- a/packages/server/src/app.module.ts
+++ b/packages/server/src/app.module.ts
@@ -62,6 +62,7 @@ import { OrganizationInvites } from './api/organizations/entities/organization-i
 import { redisStore } from 'cache-manager-redis-yet';
 import { CacheModule } from '@nestjs/cache-manager';
 import { HealthCheckService } from './app.healthcheck.service';
+import { QueueService } from '@/common/services/queue.service';
 
 const sensitiveKeys = [
   /cookie/i,
@@ -102,6 +103,7 @@ function getProvidersList() {
     RedlockService,
     JourneyLocationsService,
     HealthCheckService,
+    QueueService
   ];
 
   if (process.env.LAUDSPEAKER_PROCESS_TYPE == 'CRON') {
@@ -268,13 +270,31 @@ export const formatMongoConnectionString = (mongoConnectionString: string) => {
       name: '{start}',
     }),
     BullModule.registerQueue({
+      name: '{start.step}',
+    }),
+    BullModule.registerQueue({
       name: '{wait.until.step}',
+    }),
+    BullModule.registerQueue({
+      name: '{message.step}',
+    }),
+    BullModule.registerQueue({
+      name: '{jump.to.step}',
     }),
     BullModule.registerQueue({
       name: '{time.delay.step}',
     }),
     BullModule.registerQueue({
       name: '{time.window.step}',
+    }),
+    BullModule.registerQueue({
+      name: '{multisplit.step}',
+    }),
+    BullModule.registerQueue({
+      name: '{experiment.step}',
+    }),
+    BullModule.registerQueue({
+      name: '{exit.step}',
     }),
     BullModule.registerQueue({
       name: '{customer_change}',

--- a/packages/server/src/common/services/queue.service.ts
+++ b/packages/server/src/common/services/queue.service.ts
@@ -1,0 +1,194 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  InjectQueue,
+} from '@nestjs/bullmq';
+import { Job, Queue } from 'bullmq';
+import { StepType } from '../../api/steps/types/step.interface';
+
+@Injectable()
+export class QueueService {
+  constructor(
+    @InjectQueue('{start.step}') 
+    private readonly startStepQueue: Queue,
+    @InjectQueue('{wait.until.step}')
+    private readonly waitUntilStepQueue: Queue,
+    @InjectQueue('{message.step}')
+    private readonly messageStepQueue: Queue,
+    @InjectQueue('{jump.to.step}')
+    private readonly jumpToStepQueue: Queue,
+    @InjectQueue('{time.delay.step}')
+    private readonly timeDelayStepQueue: Queue,
+    @InjectQueue('{time.window.step}')
+    private readonly timeWindowStepQueue: Queue,
+    @InjectQueue('{multisplit.step}')
+    private readonly multisplitStepQueue: Queue,
+    @InjectQueue('{experiment.step}')
+    private readonly experimentStepQueue: Queue,
+    @InjectQueue('{exit.step}')
+    private readonly exitStepQueue: Queue
+  ) {}
+
+  private getQueueMap() {
+    const queueMap = {
+      [StepType.START]: this.startStepQueue,
+      [StepType.EXPERIMENT]: this.experimentStepQueue,
+      [StepType.LOOP]: this.jumpToStepQueue,
+      [StepType.EXIT]: this.exitStepQueue,
+      [StepType.MULTISPLIT]: this.multisplitStepQueue,
+      [StepType.MESSAGE]: this.messageStepQueue,
+      [StepType.TIME_WINDOW]: this.timeWindowStepQueue,
+      [StepType.TIME_DELAY]: this.timeDelayStepQueue,
+      [StepType.WAIT_UNTIL_BRANCH]: this.waitUntilStepQueue,
+    }
+
+    return queueMap;
+  }
+
+  private getQueueForStepType(type: StepType) {
+    const queueMap = this.getQueueMap();
+
+    const queue = queueMap[type];
+
+    if(!queue) {
+      throw new Error('Function ${type} is not implemented.');
+    }
+
+    return queue;
+  }
+
+  private getStepDepthFromBulkJob(jobs: any[]) {
+    let depths = new Set();
+
+    for (const job of jobs) {
+      if (job.stepDepth)
+        depth.add(+job.stepDepth);
+    }
+
+    // default to stepDepth of 1
+    if(depths.size == 0)
+      return 1;
+
+    // get first value
+    let it = depths.values();
+    let first = it.next();
+    let stepDepth = first.value;
+
+    return stepDepth;
+  }
+
+  private getStepDepthFromJob(job: any) {
+    const stepDepth = this.getStepDepthFromBulkJob([job]);
+
+    return stepDepth;
+  }
+
+  /**
+   * Generate batchSize priorities for step jobs at a depth stepDepth
+   * @param stepDepth (non-zero number)
+   * @param batchSize
+   * @returns
+   */
+  private getBulkJobPriority(
+    stepDepth: number,
+    batchSize: number
+  ): number[] {
+    const priorities: number[] = [];
+
+    // bullmq max priority
+    const maxJobPriority: number = 2000000;
+
+    // max number of steps a journey can take
+    const maxJourneyDepth: number = 1000;
+
+    // upperbound to maxJourneyDepth
+    stepDepth = Math.min(stepDepth, maxJourneyDepth);
+
+    // priorities will be [1, stepPriorityBlocks[, [stepPriorityBlocks, 2 * stepPriorityBlocks[, etc...
+    const stepPriorityBlocks: number = Math.floor(maxJobPriority / maxJourneyDepth);
+
+    const nextStepPriorityStart: number = (stepDepth - 1) * stepPriorityBlocks + 1;
+    const nextStepPriorityEnd: number = nextStepPriorityStart + stepPriorityBlocks - 1;
+
+    let nextStepPriority;
+
+    for(let i = 0; i < batchSize; i++) {
+      nextStepPriority = Math.floor(Math.random() * (nextStepPriorityEnd - nextStepPriorityStart + 1) + nextStepPriorityStart);
+
+      priorities.push(nextStepPriority);
+    }
+
+    return priorities;
+  }
+
+  /**
+   * Get priority for a single job at a depth stepDepth
+   * @param stepDepth (non-zero number)
+   * @returns
+   */
+  private getJobPriority(stepDepth: number): number {
+    const priorities = this.getBulkJobPriority(stepDepth, 1);
+
+    return priorities[0];
+  }
+
+  /**
+   * Adds bulk jobsData to specific queue, can be used for early queues if there
+   * is no stepType (enrollment, start)
+   * @param queue
+   * @param job
+   * @param priority
+   * @returns
+   */
+  async addBulkToQueue(queue: Queue, name: string, jobsData: any[]) {
+    const stepDepth = this.getStepDepthFromBulkJob(jobsData);
+    const priorities = this.getBulkJobPriority(stepDepth, jobsData.length);
+    const jobs: Record<string, any>[];
+
+    for(let i = 0; i < jobsData.length; i++) {
+      jobs.add({
+        name: name,
+        data: jobData,
+        opts: {
+          priority: priorities[i],
+        }
+      })
+    }
+
+    await queue.addBulk(jobs);
+  }
+
+  /**
+   * Creates a job from jobData and adds a job to specific queue,
+   * can be used for early queues if there is no stepType (enrollment, start)
+   * @param queue
+   * @param jobData
+   * @returns
+   */
+  async addToQueue(queue: Queue, name: string, jobData: any) {
+    await this.addBulkToQueue(queue, name, [jobData]);
+  }
+
+  /**
+   * create jobs from jobsData and add them in bulk it to a queue based on the stepType
+   * @param stepType
+   * @param jobData
+   * @returns
+   */
+  async addBulk(type: StepType, jobsData: any[]) {
+    const queue = this.getQueueForStepType(type);
+
+    await this.addBulkToQueue(queue, type, jobsData);
+  }
+
+  /**
+   * create a job from jobData and add it to a queue based on the stepType
+   * @param stepType
+   * @param jobData
+   * @returns
+   */
+  async add(type: StepType, jobData: any) {
+    const queue = this.getQueueForStepType(type);
+
+    await this.addToQueue(queue, type, job);
+  }
+}


### PR DESCRIPTION
This PR makes it possible for journeys to be processed simultaneously. If more than one journey has started, the first step of each journey will be uniformly processed together, instead of one at a time.

Each step has an associated depth in its own journey, and is passed around in the job data as the customer progresses through the journey. Each time a step is completed, the new job for the next step will a stepDepth number that is `1 + current job's stepDepth`.

Each step depth has a block of numbers resembling priorities. Currently each step has a block of `2000` numbers, assuming that the max number of steps a journey can go through is `1000 steps` and that the max priority that can be set for bullMQ is `2,000,000`