### PR TITLE
prevent processors from being loaded more than once

### DIFF
--- a/packages/server/src/api/events/events.module.ts
+++ b/packages/server/src/api/events/events.module.ts
@@ -78,15 +78,6 @@ function getProvidersList() {
       EventsProcessor,
       EventsPreProcessor,
       EventsPostProcessor,
-      ExitStepProcessor,
-      ExperimentStepProcessor,
-      JumpToStepProcessor,
-      MessageStepProcessor,
-      MultisplitStepProcessor,
-      StartStepProcessor,
-      TimeDelayStepProcessor,
-      TimeWindowStepProcessor,
-      WaitUntilStepProcessor,
     ];
   }
 

--- a/packages/server/src/api/segments/segments.module.ts
+++ b/packages/server/src/api/segments/segments.module.ts
@@ -27,7 +27,6 @@ function getProvidersList() {
     providerList = [
       ...providerList,
       SegmentUpdateProcessor,
-      CustomerChangeProcessor,
     ];
   }
 
@@ -41,7 +40,6 @@ function getExportList() {
     exportList = [
       ...exportList,
       SegmentUpdateProcessor,
-      CustomerChangeProcessor,
     ];
   }
 


### PR DESCRIPTION
Some processors were loaded twice based on how the modules are being loaded, causing the # of consumers to increase for some processors. Now all queues should have the exact number of consumers.
![image](https://github.com/user-attachments/assets/1297bb7b-5539-4eaa-9ed0-81f3ac66df0b)
