### PR TITLE
Fix customer key search input, populate it with data by changing key

### DIFF
--- a/packages/client/src/pages/PeopleTablev2/PeopleTablev2.tsx
+++ b/packages/client/src/pages/PeopleTablev2/PeopleTablev2.tsx
@@ -129,13 +129,12 @@ const PeopleTablev2 = () => {
   const loadPossibleKeys = async (q: string) => {
     const { data } = await ApiService.get<
       {
-        key: string;
+        name: string;
       }[]
     >({
       url: `/customers/possible-attributes?key=${q}`,
     });
-
-    setPossibleKeys(data.map((item) => item.key));
+    setPossibleKeys(data.map((item) => item.name));
   };
 
   useDebounce(


### PR DESCRIPTION

https://github.com/user-attachments/assets/2288b773-d1f4-4337-afe4-766ef2ec5430

Fix customer key search input, populate it with data by changing key of received api data
The search options were not being populated so an 'undefined' was assigned as a value. 

