### PR TITLE
Introduce Customer Aliases

### DIFF
--- a/packages/server/src/api/customers/entities/customer-alias.entity.ts
+++ b/packages/server/src/api/customers/entities/customer-alias.entity.ts
@@ -1,0 +1,40 @@
+import { Customer } from './customer.entity';
+import { Workspaces } from '../../workspaces/entities/workspaces.entity';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  JoinColumn,
+  ManyToOne,
+  Index,
+} from 'typeorm';
+
+@Entity({ name: 'customer_aliases' })
+export class Customer {
+  @PrimaryGeneratedColumn('increment', { type: 'bigserial' })
+  id: string;
+
+  @JoinColumn({ name: 'customer_id' })
+  @ManyToOne(() => Customer, (customer) => customer.id, {
+    onDelete: 'CASCADE',
+  })
+  customer: Customer;
+
+  @Column({ type: 'uuid', unique: true, nullable: false })
+  @Index()
+  uuid: string;
+
+
+  @CreateDateColumn({ type: 'timestamp', default: () => 'NOW()' })
+  @Index()
+  created_at: Date;
+
+
+  @JoinColumn({ name: 'workspace_id' })
+  @ManyToOne(() => Workspaces, (workspace) => workspace.id, {
+    onDelete: 'CASCADE',
+  })
+  workspace: Workspaces;
+}

--- a/packages/server/src/migrations/1743116243786-CreateCustomerAliasesTable.ts
+++ b/packages/server/src/migrations/1743116243786-CreateCustomerAliasesTable.ts
@@ -1,0 +1,84 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class CreateCustomerAliasesTable1743116243786 implements MigrationInterface {
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: "customer_aliases",
+        columns: [
+          {
+            name: "id",
+            type: "bigserial",
+            isPrimary: true,
+          },
+          {
+            name: "created_at",
+            type: "timestamp",
+            default: "now()",
+          },
+          {
+            name: "customer_id",
+            type: "bigint",
+          },
+          {
+            name: "uuid",
+            type: "UUID",
+          },
+          {
+            name: "workspace_id",
+            type: "UUID",
+          },
+        ],
+      })
+    );
+
+    await queryRunner.createForeignKeys(
+      "customer_aliases",
+      [
+        new TableForeignKey({
+            columnNames: ["customer_id"],
+            referencedColumnNames: ["id"],
+            referencedTableName: "customers",
+            onDelete: "CASCADE",
+        }),
+        new TableForeignKey({
+            columnNames: ["workspace_id"],
+            referencedColumnNames: ["id"],
+            referencedTableName: "workspaces",
+            onDelete: "CASCADE",
+        }),        
+      ]
+    );
+
+    await queryRunner.createIndices(
+      "customer_aliases",
+      [
+        new TableIndex({
+          name: "idx_customer_aliases_workspace_id",
+          columnNames: ["workspace_id"]
+        }),
+        new TableIndex({
+          name: "idx_customer_aliases_created_at",
+          columnNames: ["workspace_id", "created_at"]
+        }),
+        new TableIndex({
+          name: "idx_customer_aliases_customer_id",
+          columnNames: ["workspace_id", "customer_id"]
+        }),
+        new TableIndex({
+          name: "idx_customer_aliases_customer_id",
+          columnNames: ["workspace_id", "uuid"]
+        }),
+        new TableIndex({
+          name: "idx_customer_aliases_multiple_1",
+          columnNames: ["workspace_id", "customer_id", "uuid"],
+          isUnique: true
+        }),
+      ]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+  }
+
+}

--- a/packages/server/src/shared/typeorm/typeorm.service.ts
+++ b/packages/server/src/shared/typeorm/typeorm.service.ts
@@ -48,7 +48,7 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
       logger: 'advanced-console',
       logging: ['warn', 'error'],
       subscribers: [],
-      synchronize: process.env.SYNCHRONIZE == 'true', // never use TRUE in production!
+      synchronize: false, // never use TRUE in production!
       autoLoadEntities: true,
       maxQueryExecutionTime: 2000,
       extra: {


### PR DESCRIPTION
This entity will replace the field `other_ids` for customers in favor of recording them in an alias table for a quicker lookup.